### PR TITLE
Anchor repositioning

### DIFF
--- a/sources/IngridDarling.glyphs
+++ b/sources/IngridDarling.glyphs
@@ -1,26 +1,34 @@
 {
-.appVersion = "3112";
+.appVersion = "1359";
 classes = (
 {
-code = "t.alt tbar.alt tcaron.alt tcedilla.alt tcommaaccent.alt ";
-name = t_class_alt;
+automatic = 1;
+code = "A Aacute Abreve Abreveacute Abrevedotbelow Abrevegrave Abrevehookabove Abrevetilde Acaron Acircumflex Acircumflexacute Acircumflexdotbelow Acircumflexgrave Acircumflexhookabove Acircumflextilde Adblgrave Adieresis Adotbelow Agrave Ahookabove Ainvertedbreve Amacron Aogonek Aring Aringacute Atilde AE AEacute B C Cacute Ccaron Ccedilla Ccircumflex Cdotaccent D DZcaron Eth Dcaron Dcroat Dzcaron E Eacute Ebreve Ecaron Ecircumflex Ecircumflexacute Ecircumflexdotbelow Ecircumflexgrave Ecircumflexhookabove Ecircumflextilde Edblgrave Edieresis Edotaccent Edotbelow Egrave Ehookabove Einvertedbreve Emacron Eogonek Etilde F G Gbreve Gcaron Gcircumflex Gcommaaccent Gdotaccent H Hbar Hcircumflex I Iacute Ibreve Icaron Icircumflex Idblgrave Idieresis Idotaccent Idotbelow Igrave Ihookabove Iinvertedbreve Imacron Iogonek Itilde J Jcircumflex K Kcommaaccent L LJ Lacute Lcaron Lcommaaccent Ldot Lj Lslash M N NJ Nacute Ncaron Ncommaaccent Eng Nj Ntilde O Oacute Obreve Ocaron Ocircumflex Ocircumflexacute Ocircumflexdotbelow Ocircumflexgrave Ocircumflexhookabove Ocircumflextilde Odblgrave Odieresis Odieresismacron Odotaccentmacron Odotbelow Ograve Ohookabove Ohorn Ohornacute Ohorndotbelow Ohorngrave Ohornhookabove Ohorntilde Ohungarumlaut Oinvertedbreve Omacron Oogonek Oslash Oslashacute Otilde Otildemacron OE P Thorn Q R Racute Rcaron Rcommaaccent Rdblgrave Rinvertedbreve S Sacute Scaron Scedilla Scircumflex Scommaaccent Germandbls Schwa T Tbar Tcaron Tcedilla Tcommaaccent U Uacute Ubreve Ucaron Ucircumflex Udblgrave Udieresis Udieresiscaron Udieresisgrave Udieresismacron Udotbelow Ugrave Uhookabove Uhorn Uhornacute Uhorndotbelow Uhorngrave Uhornhookabove Uhorntilde Uhungarumlaut Uinvertedbreve Umacron Uogonek Uring Utilde V W Wacute Wcircumflex Wdieresis Wgrave X Y Yacute Ycircumflex Ydieresis Ydotbelow Ygrave Yhookabove Ymacron Ytilde Z Zacute Zcaron Zdotaccent";
+name = Uppercase;
+},
+{
+code = "a aacute abreve abreveacute abrevedotbelow abrevegrave abrevehookabove abrevetilde acaron acircumflex acircumflexacute acircumflexdotbelow acircumflexgrave acircumflexhookabove acircumflextilde adblgrave adieresis adotbelow agrave ahookabove ainvertedbreve amacron aogonek aring aringacute atilde ";
+name = a_class;
 },
 {
 code = "e eacute ebreve ecaron ecircumflex ecircumflexacute ecircumflexdotbelow ecircumflexgrave ecircumflexhookabove ecircumflextilde edblgrave edieresis edotaccent edotbelow egrave ehookabove einvertedbreve emacron eogonek etilde ";
 name = e_class;
 },
 {
+code = "i idotless iacute ibreve icaron icircumflex idblgrave idieresis idotaccent idotbelow igrave ihookabove iinvertedbreve imacron iogonek itilde ";
+name = i_class;
+},
+{
+code = "o oacute obreve ocaron ocircumflex ocircumflexacute ocircumflexdotbelow ocircumflexgrave ocircumflexhookabove ocircumflextilde odblgrave odieresis odieresismacron odotaccentmacron odotbelow ograve ohookabove ohorn ohornacute ohorndotbelow ohorngrave ohornhookabove ohorntilde ohungarumlaut oinvertedbreve omacron oogonek oslash oslashacute otilde otildemacron ";
+name = o_class;
+},
+{
 code = "t tbar tcaron tcedilla tcommaaccent ";
 name = t_class;
 },
 {
-automatic = 1;
-code = "A Aacute Abreve Abreveacute Abrevedotbelow Abrevegrave Abrevehookabove Abrevetilde Acaron Acircumflex Acircumflexacute Acircumflexdotbelow Acircumflexgrave Acircumflexhookabove Acircumflextilde Adblgrave Adieresis Adotbelow Agrave Ahookabove Ainvertedbreve Amacron Aogonek Aring Aringacute Atilde AE AEacute B C Cacute Ccaron Ccedilla Ccircumflex Cdotaccent D DZcaron Eth Dcaron Dcroat Dzcaron E Eacute Ebreve Ecaron Ecircumflex Ecircumflexacute Ecircumflexdotbelow Ecircumflexgrave Ecircumflexhookabove Ecircumflextilde Edblgrave Edieresis Edotaccent Edotbelow Egrave Ehookabove Einvertedbreve Emacron Eogonek Etilde Schwa F G Gbreve Gcaron Gcircumflex Gcommaaccent Gdotaccent H Hbar Hcircumflex I Iacute Ibreve Icaron Icircumflex Idblgrave Idieresis Idotaccent Idotbelow Igrave Ihookabove Iinvertedbreve Imacron Iogonek Itilde J Jcircumflex K Kcommaaccent L LJ Lacute Lcaron Lcommaaccent Ldot Lj Lslash M N NJ Nacute Ncaron Ncommaaccent Nj Ntilde Eng O Oacute Obreve Ocaron Ocircumflex Ocircumflexacute Ocircumflexdotbelow Ocircumflexgrave Ocircumflexhookabove Ocircumflextilde Odblgrave Odieresis Odieresismacron Odotaccentmacron Odotbelow Ograve Ohookabove Ohorn Ohornacute Ohorndotbelow Ohorngrave Ohornhookabove Ohorntilde Ohungarumlaut Oinvertedbreve Omacron Oogonek Oslash Oslashacute Otilde Otildemacron OE P Thorn Q R Racute Rcaron Rcommaaccent Rdblgrave Rinvertedbreve S Sacute Scaron Scedilla Scircumflex Scommaaccent Germandbls T Tbar Tcaron Tcedilla Tcommaaccent U Uacute Ubreve Ucaron Ucircumflex Udblgrave Udieresis Udieresiscaron Udieresisgrave Udieresismacron Udotbelow Ugrave Uhookabove Uhorn Uhornacute Uhorndotbelow Uhorngrave Uhornhookabove Uhorntilde Uhungarumlaut Uinvertedbreve Umacron Uogonek Uring Utilde V W Wacute Wcircumflex Wdieresis Wgrave X Y Yacute Ycircumflex Ydieresis Ydotbelow Ygrave Yhookabove Ymacron Ytilde Z Zacute Zcaron Zdotaccent";
-name = Uppercase;
-},
-{
-code = "i idotless iacute ibreve icaron icircumflex idblgrave idieresis idotaccent idotbelow igrave ihookabove iinvertedbreve imacron iogonek itilde ";
-name = i_class;
+code = "t.alt tbar.alt tcaron.alt tcedilla.alt tcommaaccent.alt ";
+name = t_class_alt;
 }
 );
 copyright = "Copyright 2014-2021 The Ingrid Darling Project Authors (https://github.com/googlefonts/ingrid-darling)";
@@ -98,12 +106,12 @@ name = Languagesystems;
 features = (
 {
 automatic = 1;
-code = "feature calt;\012feature locl;\012feature sups;\012feature frac;\012feature ordn;\012feature case;\012";
+code = "feature locl;\012feature calt;\012feature sups;\012feature frac;\012feature ordn;\012feature case;\012";
 name = aalt;
 },
 {
 automatic = 1;
-code = "lookup ccmp_Other_1 {\012	@CombiningTopAccents = [acutecomb brevecomb breveinvertedcomb caroncomb circumflexcomb commaturnedabovecomb dblgravecomb dieresiscomb dotaccentcomb gravecomb hookabovecomb hungarumlautcomb macroncomb ringcomb tildecomb];\012	@CombiningNonTopAccents = [brevebelowcomb cedillacomb dieresisbelowcomb dotbelowcomb macronbelowcomb ogonekcomb horncomb strokeshortcomb];\012	sub [i j]' @CombiningTopAccents by [idotless jdotless];\012	sub [i j]' @CombiningNonTopAccents @CombiningTopAccents by [idotless jdotless];\012	@Markscomb = [dieresiscomb dotaccentcomb gravecomb acutecomb hungarumlautcomb circumflexcomb circumflexcomb_gravecomb circumflexcomb_acutecomb circumflexcomb_tildecomb circumflexcomb_hookabovecomb caroncomb brevecomb brevecomb_gravecomb brevecomb_acutecomb brevecomb_tildecomb brevecomb_hookabovecomb ringcomb ringcomb_acutecomb tildecomb tildecomb_dotaccentcomb tildecomb_macroncomb macroncomb hookabovecomb dblgravecomb breveinvertedcomb commaturnedabovecomb dotbelowcomb dieresisbelowcomb commaaccentcomb brevebelowcomb macronbelowcomb];\012	@MarkscombCase = [dieresiscomb.case dotaccentcomb.case gravecomb.case acutecomb.case hungarumlautcomb.case circumflexcomb.case circumflexcomb_gravecomb.case circumflexcomb_acutecomb.case circumflexcomb_tildecomb.case circumflexcomb_hookabovecomb.case caroncomb.case brevecomb.case brevecomb_gravecomb.case brevecomb_acutecomb.case brevecomb_tildecomb.case brevecomb_hookabovecomb.case ringcomb.case ringcomb_acutecomb.case tildecomb.case tildecomb_dotaccentcomb.case tildecomb_macroncomb.case macroncomb.case hookabovecomb.case dblgravecomb.case breveinvertedcomb.case commaturnedabovecomb.case dotbelowcomb.case dieresisbelowcomb.case commaaccentcomb.case brevebelowcomb.case macronbelowcomb.case];\012	sub @Markscomb @Markscomb' by @MarkscombCase;\012	sub @Uppercase @Markscomb' by @MarkscombCase;\012} ccmp_Other_1;\012\012lookup ccmp_Other_2 {\012	sub @Markscomb' @MarkscombCase by @MarkscombCase;\012	sub @MarkscombCase @Markscomb' by @MarkscombCase;\012} ccmp_Other_2;\012\012lookup ccmp_Other_3 {\012	lookupflag 0;\012	sub ringcomb acutecomb by ringcomb_acutecomb;\012	sub tildecomb dotaccentcomb by tildecomb_dotaccentcomb;\012	sub tildecomb macroncomb by tildecomb_macroncomb;\012} ccmp_Other_3;\012\012lookup ccmp_latn_1 {\012	sub fi by f i;\012	sub fl by f l;\012	sub Ldot by L periodcentered.loclCAT.case;\012	sub lj by l j;\012	sub Lj by L j;\012	sub LJ by L J;\012	sub nj by n j;\012	sub Nj by N j;\012	sub NJ by N J;\012	sub dzcaron by d zcaron;\012	sub Dzcaron by D zcaron;\012	sub DZcaron by D Zcaron;\012} ccmp_latn_1;\012\012lookup ccmp_latn_2 {\012	lookupflag 0;\012	sub brevecomb acutecomb by brevecomb_acutecomb;\012	sub brevecomb gravecomb by brevecomb_gravecomb;\012	sub brevecomb hookabovecomb by brevecomb_hookabovecomb;\012	sub brevecomb tildecomb by brevecomb_tildecomb;\012	sub circumflexcomb acutecomb by circumflexcomb_acutecomb;\012	sub circumflexcomb gravecomb by circumflexcomb_gravecomb;\012	sub circumflexcomb hookabovecomb by circumflexcomb_hookabovecomb;\012	sub circumflexcomb tildecomb by circumflexcomb_tildecomb;\012} ccmp_latn_2;\012\012script latn;\012lookup ccmp_latn_1;\012lookup ccmp_latn_2;\012";
+code = "lookup ccmp_Other_1 {\012	@CombiningTopAccents = [acutecomb brevecomb breveinvertedcomb caroncomb circumflexcomb commaturnedabovecomb dblgravecomb dieresiscomb dotaccentcomb gravecomb hookabovecomb hungarumlautcomb macroncomb ringcomb tildecomb];\012	@CombiningNonTopAccents = [brevebelowcomb cedillacomb dieresisbelowcomb dotbelowcomb macronbelowcomb ogonekcomb horncomb strokeshortcomb];\012	sub [i j]' @CombiningTopAccents by [idotless jdotless];\012	sub [i j]' @CombiningNonTopAccents @CombiningTopAccents by [idotless jdotless];\012	@Markscomb = [dieresiscomb dotaccentcomb gravecomb acutecomb hungarumlautcomb circumflexcomb caroncomb brevecomb ringcomb ringcomb_acutecomb tildecomb tildecomb_dotaccentcomb tildecomb_macroncomb macroncomb hookabovecomb dblgravecomb breveinvertedcomb commaturnedabovecomb dotbelowcomb dieresisbelowcomb commaaccentcomb brevebelowcomb macronbelowcomb brevecomb_acutecomb brevecomb_gravecomb brevecomb_hookabovecomb brevecomb_tildecomb circumflexcomb_acutecomb circumflexcomb_gravecomb circumflexcomb_hookabovecomb circumflexcomb_tildecomb];\012	@MarkscombCase = [dieresiscomb.case dotaccentcomb.case gravecomb.case acutecomb.case hungarumlautcomb.case circumflexcomb.case caroncomb.case brevecomb.case ringcomb.case ringcomb_acutecomb.case tildecomb.case tildecomb_dotaccentcomb.case tildecomb_macroncomb.case macroncomb.case hookabovecomb.case dblgravecomb.case breveinvertedcomb.case commaturnedabovecomb.case dotbelowcomb.case dieresisbelowcomb.case commaaccentcomb.case brevebelowcomb.case macronbelowcomb.case brevecomb_acutecomb.case brevecomb_gravecomb.case brevecomb_hookabovecomb.case brevecomb_tildecomb.case circumflexcomb_acutecomb.case circumflexcomb_gravecomb.case circumflexcomb_hookabovecomb.case circumflexcomb_tildecomb.case];\012	sub @Markscomb @Markscomb' by @MarkscombCase;\012	sub @Uppercase @Markscomb' by @MarkscombCase;\012} ccmp_Other_1;\012\012lookup ccmp_Other_2 {\012	sub @Markscomb' @MarkscombCase by @MarkscombCase;\012	sub @MarkscombCase @Markscomb' by @MarkscombCase;\012} ccmp_Other_2;\012\012lookup ccmp_Other_3 {\012	lookupflag 0;\012	sub ringcomb acutecomb by ringcomb_acutecomb;\012	sub ringcomb.case acutecomb.case by ringcomb_acutecomb.case;\012	sub tildecomb dotaccentcomb by tildecomb_dotaccentcomb;\012	sub tildecomb.case dotaccentcomb.case by tildecomb_dotaccentcomb.case;\012	sub tildecomb macroncomb by tildecomb_macroncomb;\012	sub tildecomb.case macroncomb.case by tildecomb_macroncomb.case;\012} ccmp_Other_3;\012\012lookup ccmp_latn_1 {\012	lookupflag 0;\012	sub brevecomb acutecomb by brevecomb_acutecomb;\012	sub brevecomb.case acutecomb.case by brevecomb_acutecomb.case;\012	sub brevecomb gravecomb by brevecomb_gravecomb;\012	sub brevecomb.case gravecomb.case by brevecomb_gravecomb.case;\012	sub brevecomb hookabovecomb by brevecomb_hookabovecomb;\012	sub brevecomb.case hookabovecomb.case by brevecomb_hookabovecomb.case;\012	sub brevecomb tildecomb by brevecomb_tildecomb;\012	sub brevecomb.case tildecomb.case by brevecomb_tildecomb.case;\012	sub circumflexcomb acutecomb by circumflexcomb_acutecomb;\012	sub circumflexcomb.case acutecomb.case by circumflexcomb_acutecomb.case;\012	sub circumflexcomb gravecomb by circumflexcomb_gravecomb;\012	sub circumflexcomb.case gravecomb.case by circumflexcomb_gravecomb.case;\012	sub circumflexcomb hookabovecomb by circumflexcomb_hookabovecomb;\012	sub circumflexcomb.case hookabovecomb.case by circumflexcomb_hookabovecomb.case;\012	sub circumflexcomb tildecomb by circumflexcomb_tildecomb;\012	sub circumflexcomb.case tildecomb.case by circumflexcomb_tildecomb.case;\012} ccmp_latn_1;\012\012script latn;\012lookup ccmp_latn_1;\012";
 name = ccmp;
 },
 {
@@ -112,7 +120,7 @@ code = "lookup locl_latn_0 {\012	script latn;\012	language AZE;\012	sub i by ido
 name = locl;
 },
 {
-code = "sub @t_class' @e_class by @t_class_alt;\012sub @i_class @t_class' by @t_class_alt;";
+code = "sub @t_class' @e_class by @t_class_alt;\012sub dcroat' @a_class by dcroat.alt;\012sub dcroat' @e_class by dcroat.alt;\012sub dcroat' @i_class by dcroat.alt;\012sub dcroat' @o_class by dcroat.alt;\012\012sub @i_class @t_class' by @t_class_alt;\012sub @o_class @t_class' by @t_class_alt;\012sub @e_class @t_class' by @t_class_alt;\012\012sub i' @e_class by e.alt';\012sub i' @o_class by i.alt';\012";
 name = calt;
 },
 {
@@ -132,7 +140,7 @@ name = ordn;
 },
 {
 automatic = 1;
-code = "sub periodcentered.loclCAT by periodcentered.loclCAT.case;\012sub dieresiscomb by dieresiscomb.case;\012sub dotaccentcomb by dotaccentcomb.case;\012sub gravecomb by gravecomb.case;\012sub acutecomb by acutecomb.case;\012sub hungarumlautcomb by hungarumlautcomb.case;\012sub circumflexcomb by circumflexcomb.case;\012sub circumflexcomb_gravecomb by circumflexcomb_gravecomb.case;\012sub circumflexcomb_acutecomb by circumflexcomb_acutecomb.case;\012sub circumflexcomb_tildecomb by circumflexcomb_tildecomb.case;\012sub circumflexcomb_hookabovecomb by circumflexcomb_hookabovecomb.case;\012sub caroncomb by caroncomb.case;\012sub brevecomb by brevecomb.case;\012sub brevecomb_gravecomb by brevecomb_gravecomb.case;\012sub brevecomb_acutecomb by brevecomb_acutecomb.case;\012sub brevecomb_tildecomb by brevecomb_tildecomb.case;\012sub brevecomb_hookabovecomb by brevecomb_hookabovecomb.case;\012sub ringcomb by ringcomb.case;\012sub ringcomb_acutecomb by ringcomb_acutecomb.case;\012sub tildecomb by tildecomb.case;\012sub tildecomb_dotaccentcomb by tildecomb_dotaccentcomb.case;\012sub tildecomb_macroncomb by tildecomb_macroncomb.case;\012sub macroncomb by macroncomb.case;\012sub hookabovecomb by hookabovecomb.case;\012sub dblgravecomb by dblgravecomb.case;\012sub breveinvertedcomb by breveinvertedcomb.case;\012sub commaturnedabovecomb by commaturnedabovecomb.case;\012sub dotbelowcomb by dotbelowcomb.case;\012sub dieresisbelowcomb by dieresisbelowcomb.case;\012sub commaaccentcomb by commaaccentcomb.case;\012sub brevebelowcomb by brevebelowcomb.case;\012sub macronbelowcomb by macronbelowcomb.case;\012";
+code = "sub periodcentered.loclCAT by periodcentered.loclCAT.case;\012sub dieresiscomb by dieresiscomb.case;\012sub dotaccentcomb by dotaccentcomb.case;\012sub gravecomb by gravecomb.case;\012sub acutecomb by acutecomb.case;\012sub hungarumlautcomb by hungarumlautcomb.case;\012sub circumflexcomb by circumflexcomb.case;\012sub caroncomb by caroncomb.case;\012sub brevecomb by brevecomb.case;\012sub ringcomb by ringcomb.case;\012sub ringcomb_acutecomb by ringcomb_acutecomb.case;\012sub tildecomb by tildecomb.case;\012sub tildecomb_dotaccentcomb by tildecomb_dotaccentcomb.case;\012sub tildecomb_macroncomb by tildecomb_macroncomb.case;\012sub macroncomb by macroncomb.case;\012sub hookabovecomb by hookabovecomb.case;\012sub dblgravecomb by dblgravecomb.case;\012sub breveinvertedcomb by breveinvertedcomb.case;\012sub commaturnedabovecomb by commaturnedabovecomb.case;\012sub dotbelowcomb by dotbelowcomb.case;\012sub dieresisbelowcomb by dieresisbelowcomb.case;\012sub commaaccentcomb by commaaccentcomb.case;\012sub brevebelowcomb by brevebelowcomb.case;\012sub macronbelowcomb by macronbelowcomb.case;\012sub brevecomb_acutecomb by brevecomb_acutecomb.case;\012sub brevecomb_gravecomb by brevecomb_gravecomb.case;\012sub brevecomb_hookabovecomb by brevecomb_hookabovecomb.case;\012sub brevecomb_tildecomb by brevecomb_tildecomb.case;\012sub circumflexcomb_acutecomb by circumflexcomb_acutecomb.case;\012sub circumflexcomb_gravecomb by circumflexcomb_gravecomb.case;\012sub circumflexcomb_hookabovecomb by circumflexcomb_hookabovecomb.case;\012sub circumflexcomb_tildecomb by circumflexcomb_tildecomb.case;\012";
 name = case;
 },
 {
@@ -616,7 +624,7 @@ unicode = 1EB4;
 },
 {
 glyphname = Acaron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:18:27 +0000";
 layers = (
 {
 components = (
@@ -625,7 +633,7 @@ name = A;
 },
 {
 name = caroncomb.case;
-transform = "{1, 0, 0, 1, 627, 329}";
+transform = "{1, 0, 0, 1, 627, 284}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -1017,7 +1025,7 @@ unicode = 00C3;
 {
 color = 3;
 glyphname = AE;
-lastChange = "2022-02-10 16:46:40 +0000";
+lastChange = "2022-02-28 13:22:55 +0000";
 layers = (
 {
 anchors = (
@@ -1027,7 +1035,7 @@ position = "{392, 0}";
 },
 {
 name = top;
-position = "{743, 585}";
+position = "{723, 545}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -1282,7 +1290,7 @@ unicode = 00C6;
 },
 {
 glyphname = AEacute;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:22:55 +0000";
 layers = (
 {
 components = (
@@ -1291,7 +1299,7 @@ name = AE;
 },
 {
 name = acutecomb.case;
-transform = "{1, 0, 0, 1, 743, 285}";
+transform = "{1, 0, 0, 1, 723, 245}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -1545,7 +1553,7 @@ unicode = 0042;
 {
 color = 3;
 glyphname = C;
-lastChange = "2022-02-10 16:46:40 +0000";
+lastChange = "2022-02-28 13:25:46 +0000";
 layers = (
 {
 anchors = (
@@ -1559,7 +1567,7 @@ position = "{254, -35}";
 },
 {
 name = top;
-position = "{376, 585}";
+position = "{376, 602}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -1703,7 +1711,7 @@ unicode = 0043;
 },
 {
 glyphname = Cacute;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:25:47 +0000";
 layers = (
 {
 components = (
@@ -1712,7 +1720,7 @@ name = C;
 },
 {
 name = acutecomb.case;
-transform = "{1, 0, 0, 1, 376, 285}";
+transform = "{1, 0, 0, 1, 376, 302}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -1725,7 +1733,7 @@ unicode = 0106;
 },
 {
 glyphname = Ccaron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:25:46 +0000";
 layers = (
 {
 components = (
@@ -1734,7 +1742,7 @@ name = C;
 },
 {
 name = caroncomb.case;
-transform = "{1, 0, 0, 1, 376, 330}";
+transform = "{1, 0, 0, 1, 376, 302}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -1769,7 +1777,7 @@ unicode = 00C7;
 },
 {
 glyphname = Ccircumflex;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:25:49 +0000";
 layers = (
 {
 components = (
@@ -1778,7 +1786,7 @@ name = C;
 },
 {
 name = circumflexcomb.case;
-transform = "{1, 0, 0, 1, 376, 285}";
+transform = "{1, 0, 0, 1, 376, 302}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -1791,7 +1799,7 @@ unicode = 0108;
 },
 {
 glyphname = Cdotaccent;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:25:49 +0000";
 layers = (
 {
 components = (
@@ -1800,7 +1808,7 @@ name = C;
 },
 {
 name = dotaccentcomb.case;
-transform = "{1, 0, 0, 1, 376, 285}";
+transform = "{1, 0, 0, 1, 376, 302}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -1814,7 +1822,7 @@ unicode = 010A;
 {
 color = 3;
 glyphname = D;
-lastChange = "2022-02-10 16:46:40 +0000";
+lastChange = "2022-02-28 13:26:04 +0000";
 layers = (
 {
 anchors = (
@@ -1824,7 +1832,7 @@ position = "{306, 0}";
 },
 {
 name = top;
-position = "{426, 585}";
+position = "{426, 552}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -2254,7 +2262,7 @@ unicode = 00D0;
 },
 {
 glyphname = Dcaron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:26:04 +0000";
 layers = (
 {
 components = (
@@ -2263,7 +2271,7 @@ name = D;
 },
 {
 name = caroncomb.case;
-transform = "{1, 0, 0, 1, 426, 330}";
+transform = "{1, 0, 0, 1, 426, 252}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -2317,7 +2325,7 @@ unicode = 01C5;
 {
 color = 3;
 glyphname = E;
-lastChange = "2022-02-17 10:38:01 +0000";
+lastChange = "2022-02-28 13:26:28 +0000";
 layers = (
 {
 anchors = (
@@ -2331,7 +2339,7 @@ position = "{378, -26}";
 },
 {
 name = top;
-position = "{416, 585}";
+position = "{406, 595}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -2478,7 +2486,7 @@ unicode = 0045;
 },
 {
 glyphname = Eacute;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:27:31 +0000";
 layers = (
 {
 components = (
@@ -2487,7 +2495,7 @@ name = E;
 },
 {
 name = acutecomb.case;
-transform = "{1, 0, 0, 1, 416, 285}";
+transform = "{1, 0, 0, 1, 406, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -2500,7 +2508,7 @@ unicode = 00C9;
 },
 {
 glyphname = Ebreve;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:27:31 +0000";
 layers = (
 {
 components = (
@@ -2509,7 +2517,7 @@ name = E;
 },
 {
 name = brevecomb.case;
-transform = "{1, 0, 0, 1, 416, 285}";
+transform = "{1, 0, 0, 1, 406, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -2522,7 +2530,7 @@ unicode = 0114;
 },
 {
 glyphname = Ecaron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:26:28 +0000";
 layers = (
 {
 components = (
@@ -2531,7 +2539,7 @@ name = E;
 },
 {
 name = caroncomb.case;
-transform = "{1, 0, 0, 1, 416, 330}";
+transform = "{1, 0, 0, 1, 406, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -2544,7 +2552,7 @@ unicode = 011A;
 },
 {
 glyphname = Ecircumflex;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -2553,7 +2561,7 @@ name = E;
 },
 {
 name = circumflexcomb.case;
-transform = "{1, 0, 0, 1, 416, 285}";
+transform = "{1, 0, 0, 1, 406, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -2566,7 +2574,7 @@ unicode = 00CA;
 },
 {
 glyphname = Ecircumflexacute;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -2575,7 +2583,7 @@ name = E;
 },
 {
 name = circumflexcomb_acutecomb.case;
-transform = "{1, 0, 0, 1, 416, 285}";
+transform = "{1, 0, 0, 1, 406, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -2588,7 +2596,7 @@ unicode = 1EBE;
 },
 {
 glyphname = Ecircumflexdotbelow;
-lastChange = "2022-02-17 10:38:01 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -2601,7 +2609,7 @@ transform = "{1, 0, 0, 1, 211, -58}";
 },
 {
 name = circumflexcomb.case;
-transform = "{1, 0, 0, 1, 416, 285}";
+transform = "{1, 0, 0, 1, 406, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -2614,7 +2622,7 @@ unicode = 1EC6;
 },
 {
 glyphname = Ecircumflexgrave;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -2623,7 +2631,7 @@ name = E;
 },
 {
 name = circumflexcomb_gravecomb.case;
-transform = "{1, 0, 0, 1, 416, 285}";
+transform = "{1, 0, 0, 1, 406, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -2636,7 +2644,7 @@ unicode = 1EC0;
 },
 {
 glyphname = Ecircumflexhookabove;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -2645,7 +2653,7 @@ name = E;
 },
 {
 name = circumflexcomb_hookabovecomb.case;
-transform = "{1, 0, 0, 1, 416, 285}";
+transform = "{1, 0, 0, 1, 406, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -2658,7 +2666,7 @@ unicode = 1EC2;
 },
 {
 glyphname = Ecircumflextilde;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -2667,7 +2675,7 @@ name = E;
 },
 {
 name = circumflexcomb_tildecomb.case;
-transform = "{1, 0, 0, 1, 416, 285}";
+transform = "{1, 0, 0, 1, 406, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -2680,7 +2688,7 @@ unicode = 1EC4;
 },
 {
 glyphname = Edblgrave;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -2689,7 +2697,7 @@ name = E;
 },
 {
 name = dblgravecomb.case;
-transform = "{1, 0, 0, 1, 416, 285}";
+transform = "{1, 0, 0, 1, 406, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -2702,7 +2710,7 @@ unicode = 0204;
 },
 {
 glyphname = Edieresis;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -2711,7 +2719,7 @@ name = E;
 },
 {
 name = dieresiscomb.case;
-transform = "{1, 0, 0, 1, 416, 285}";
+transform = "{1, 0, 0, 1, 406, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -2724,7 +2732,7 @@ unicode = 00CB;
 },
 {
 glyphname = Edotaccent;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -2733,7 +2741,7 @@ name = E;
 },
 {
 name = dotaccentcomb.case;
-transform = "{1, 0, 0, 1, 416, 285}";
+transform = "{1, 0, 0, 1, 406, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -2768,7 +2776,7 @@ unicode = 1EB8;
 },
 {
 glyphname = Egrave;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -2777,7 +2785,7 @@ name = E;
 },
 {
 name = gravecomb.case;
-transform = "{1, 0, 0, 1, 416, 285}";
+transform = "{1, 0, 0, 1, 406, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -2790,7 +2798,7 @@ unicode = 00C8;
 },
 {
 glyphname = Ehookabove;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -2799,7 +2807,7 @@ name = E;
 },
 {
 name = hookabovecomb.case;
-transform = "{1, 0, 0, 1, 416, 285}";
+transform = "{1, 0, 0, 1, 406, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -2812,7 +2820,7 @@ unicode = 1EBA;
 },
 {
 glyphname = Einvertedbreve;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -2821,7 +2829,7 @@ name = E;
 },
 {
 name = breveinvertedcomb.case;
-transform = "{1, 0, 0, 1, 416, 285}";
+transform = "{1, 0, 0, 1, 406, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -2834,7 +2842,7 @@ unicode = 0206;
 },
 {
 glyphname = Emacron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -2843,7 +2851,7 @@ name = E;
 },
 {
 name = macroncomb.case;
-transform = "{1, 0, 0, 1, 416, 285}";
+transform = "{1, 0, 0, 1, 406, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -2878,7 +2886,7 @@ unicode = 0118;
 },
 {
 glyphname = Etilde;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -2887,7 +2895,7 @@ name = E;
 },
 {
 name = tildecomb.case;
-transform = "{1, 0, 0, 1, 416, 285}";
+transform = "{1, 0, 0, 1, 406, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -2897,140 +2905,6 @@ width = 588;
 leftKerningGroup = E;
 rightKerningGroup = E;
 unicode = 1EBC;
-},
-{
-glyphname = Schwa;
-lastChange = "2022-02-07 21:15:03 +0000";
-layers = (
-{
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"94 549 OFFCURVE",
-"89 540 OFFCURVE",
-"89 532 CURVE SMOOTH",
-"89 526 OFFCURVE",
-"93 522 OFFCURVE",
-"99 522 CURVE SMOOTH",
-"104 522 OFFCURVE",
-"112 526 OFFCURVE",
-"121 534 CURVE SMOOTH",
-"143 554 OFFCURVE",
-"204 586 OFFCURVE",
-"235 594 CURVE SMOOTH",
-"262 602 OFFCURVE",
-"289 606 OFFCURVE",
-"322 606 CURVE SMOOTH",
-"331 606 OFFCURVE",
-"341 606 OFFCURVE",
-"351 605 CURVE SMOOTH",
-"417 601 OFFCURVE",
-"455 552 OFFCURVE",
-"494 515 CURVE SMOOTH",
-"528 482 OFFCURVE",
-"540 445 OFFCURVE",
-"540 390 CURVE SMOOTH",
-"540 365 OFFCURVE",
-"537 337 OFFCURVE",
-"533 304 CURVE SMOOTH",
-"527 261 OFFCURVE",
-"507 197 OFFCURVE",
-"492 169 CURVE SMOOTH",
-"461 113 OFFCURVE",
-"425 56 OFFCURVE",
-"368 24 CURVE SMOOTH",
-"337 7 OFFCURVE",
-"298 -18 OFFCURVE",
-"235 -18 CURVE SMOOTH",
-"222 -18 OFFCURVE",
-"208 -17 OFFCURVE",
-"193 -15 CURVE SMOOTH",
-"140 -5 OFFCURVE",
-"114 12 OFFCURVE",
-"95 49 CURVE SMOOTH",
-"89 60 OFFCURVE",
-"85 76 OFFCURVE",
-"85 95 CURVE SMOOTH",
-"85 112 OFFCURVE",
-"88 131 OFFCURVE",
-"97 149 CURVE SMOOTH",
-"123 205 OFFCURVE",
-"212 277 OFFCURVE",
-"320 300 CURVE SMOOTH",
-"371 298 OFFCURVE",
-"393 298 OFFCURVE",
-"438 283 CURVE SMOOTH",
-"476 268 OFFCURVE",
-"493 240 OFFCURVE",
-"498 231 CURVE SMOOTH",
-"507 220 OFFCURVE",
-"520 214 OFFCURVE",
-"530 214 CURVE SMOOTH",
-"539 214 OFFCURVE",
-"545 218 OFFCURVE",
-"545 226 CURVE SMOOTH",
-"545 230 OFFCURVE",
-"543 236 OFFCURVE",
-"538 243 CURVE SMOOTH",
-"529 254 OFFCURVE",
-"507 299 OFFCURVE",
-"458 314 CURVE SMOOTH",
-"412 330 OFFCURVE",
-"400 334 OFFCURVE",
-"363 334 CURVE SMOOTH",
-"354 334 OFFCURVE",
-"342 333 OFFCURVE",
-"328 333 CURVE SMOOTH",
-"129 325 OFFCURVE",
-"101 232 OFFCURVE",
-"70 162 CURVE SMOOTH",
-"60 139 OFFCURVE",
-"56 116 OFFCURVE",
-"56 94 CURVE SMOOTH",
-"56 68 OFFCURVE",
-"61 45 OFFCURVE",
-"70 29 CURVE SMOOTH",
-"92 -13 OFFCURVE",
-"138 -59 OFFCURVE",
-"202 -69 CURVE SMOOTH",
-"221 -72 OFFCURVE",
-"238 -74 OFFCURVE",
-"253 -74 CURVE SMOOTH",
-"319 -74 OFFCURVE",
-"361 -48 OFFCURVE",
-"393 -29 CURVE SMOOTH",
-"455 7 OFFCURVE",
-"497 70 OFFCURVE",
-"529 130 CURVE SMOOTH",
-"546 162 OFFCURVE",
-"570 231 OFFCURVE",
-"575 279 CURVE SMOOTH",
-"578 303 OFFCURVE",
-"580 327 OFFCURVE",
-"580 349 CURVE SMOOTH",
-"580 431 OFFCURVE",
-"557 497 OFFCURVE",
-"515 540 CURVE SMOOTH",
-"475 579 OFFCURVE",
-"430 633 OFFCURVE",
-"355 637 CURVE SMOOTH",
-"303 640 OFFCURVE",
-"268 635 OFFCURVE",
-"230 625 CURVE SMOOTH",
-"197 617 OFFCURVE",
-"128 581 OFFCURVE",
-"104 559 CURVE SMOOTH"
-);
-}
-);
-width = 592;
-}
-);
-leftKerningGroup = Schwa;
-rightKerningGroup = O;
-unicode = 018F;
 },
 {
 glyphname = F;
@@ -3265,7 +3139,7 @@ unicode = 0046;
 {
 color = 3;
 glyphname = G;
-lastChange = "2022-02-17 10:37:39 +0000";
+lastChange = "2022-02-28 13:27:42 +0000";
 layers = (
 {
 anchors = (
@@ -3275,7 +3149,7 @@ position = "{198, -385}";
 },
 {
 name = top;
-position = "{420, 585}";
+position = "{420, 595}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -3446,7 +3320,7 @@ unicode = 0047;
 },
 {
 glyphname = Gbreve;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -3455,7 +3329,7 @@ name = G;
 },
 {
 name = brevecomb.case;
-transform = "{1, 0, 0, 1, 420, 285}";
+transform = "{1, 0, 0, 1, 420, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -3468,7 +3342,7 @@ unicode = 011E;
 },
 {
 glyphname = Gcaron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:27:42 +0000";
 layers = (
 {
 components = (
@@ -3477,7 +3351,7 @@ name = G;
 },
 {
 name = caroncomb.case;
-transform = "{1, 0, 0, 1, 420, 330}";
+transform = "{1, 0, 0, 1, 420, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -3490,7 +3364,7 @@ unicode = 01E6;
 },
 {
 glyphname = Gcircumflex;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -3499,7 +3373,7 @@ name = G;
 },
 {
 name = circumflexcomb.case;
-transform = "{1, 0, 0, 1, 420, 285}";
+transform = "{1, 0, 0, 1, 420, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -3534,7 +3408,7 @@ unicode = 0122;
 },
 {
 glyphname = Gdotaccent;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -3543,7 +3417,7 @@ name = G;
 },
 {
 name = dotaccentcomb.case;
-transform = "{1, 0, 0, 1, 420, 285}";
+transform = "{1, 0, 0, 1, 420, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -3863,7 +3737,7 @@ unicode = 0124;
 {
 color = 1;
 glyphname = I;
-lastChange = "2022-02-17 10:39:32 +0000";
+lastChange = "2022-02-28 13:28:55 +0000";
 layers = (
 {
 anchors = (
@@ -3877,7 +3751,7 @@ position = "{503, 31}";
 },
 {
 name = top;
-position = "{549, 585}";
+position = "{541, 565}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -4044,7 +3918,7 @@ unicode = 0049;
 },
 {
 glyphname = Iacute;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -4053,7 +3927,7 @@ name = I;
 },
 {
 name = acutecomb.case;
-transform = "{1, 0, 0, 1, 549, 285}";
+transform = "{1, 0, 0, 1, 541, 265}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -4066,7 +3940,7 @@ unicode = 00CD;
 },
 {
 glyphname = Ibreve;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -4075,7 +3949,7 @@ name = I;
 },
 {
 name = brevecomb.case;
-transform = "{1, 0, 0, 1, 549, 285}";
+transform = "{1, 0, 0, 1, 541, 265}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -4088,7 +3962,7 @@ unicode = 012C;
 },
 {
 glyphname = Icaron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:55 +0000";
 layers = (
 {
 components = (
@@ -4097,7 +3971,7 @@ name = I;
 },
 {
 name = caroncomb.case;
-transform = "{1, 0, 0, 1, 549, 330}";
+transform = "{1, 0, 0, 1, 541, 265}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -4110,7 +3984,7 @@ unicode = 01CF;
 },
 {
 glyphname = Icircumflex;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -4119,7 +3993,7 @@ name = I;
 },
 {
 name = circumflexcomb.case;
-transform = "{1, 0, 0, 1, 549, 285}";
+transform = "{1, 0, 0, 1, 541, 265}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -4132,7 +4006,7 @@ unicode = 00CE;
 },
 {
 glyphname = Idblgrave;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -4141,7 +4015,7 @@ name = I;
 },
 {
 name = dblgravecomb.case;
-transform = "{1, 0, 0, 1, 549, 285}";
+transform = "{1, 0, 0, 1, 541, 265}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -4154,7 +4028,7 @@ unicode = 0208;
 },
 {
 glyphname = Idieresis;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -4163,7 +4037,7 @@ name = I;
 },
 {
 name = dieresiscomb.case;
-transform = "{1, 0, 0, 1, 549, 285}";
+transform = "{1, 0, 0, 1, 541, 265}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -4176,7 +4050,7 @@ unicode = 00CF;
 },
 {
 glyphname = Idotaccent;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -4185,7 +4059,7 @@ name = I;
 },
 {
 name = dotaccentcomb.case;
-transform = "{1, 0, 0, 1, 549, 285}";
+transform = "{1, 0, 0, 1, 541, 265}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -4220,7 +4094,7 @@ unicode = 1ECA;
 },
 {
 glyphname = Igrave;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -4229,7 +4103,7 @@ name = I;
 },
 {
 name = gravecomb.case;
-transform = "{1, 0, 0, 1, 549, 285}";
+transform = "{1, 0, 0, 1, 541, 265}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -4242,7 +4116,7 @@ unicode = 00CC;
 },
 {
 glyphname = Ihookabove;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -4251,7 +4125,7 @@ name = I;
 },
 {
 name = hookabovecomb.case;
-transform = "{1, 0, 0, 1, 549, 285}";
+transform = "{1, 0, 0, 1, 541, 265}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -4264,7 +4138,7 @@ unicode = 1EC8;
 },
 {
 glyphname = Iinvertedbreve;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -4273,7 +4147,7 @@ name = I;
 },
 {
 name = breveinvertedcomb.case;
-transform = "{1, 0, 0, 1, 549, 285}";
+transform = "{1, 0, 0, 1, 541, 265}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -4286,7 +4160,7 @@ unicode = 020A;
 },
 {
 glyphname = Imacron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -4295,7 +4169,7 @@ name = I;
 },
 {
 name = macroncomb.case;
-transform = "{1, 0, 0, 1, 549, 285}";
+transform = "{1, 0, 0, 1, 541, 265}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -4330,7 +4204,7 @@ unicode = 012E;
 },
 {
 glyphname = Itilde;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:28:58 +0000";
 layers = (
 {
 components = (
@@ -4339,7 +4213,7 @@ name = I;
 },
 {
 name = tildecomb.case;
-transform = "{1, 0, 0, 1, 549, 285}";
+transform = "{1, 0, 0, 1, 541, 265}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -4353,7 +4227,7 @@ unicode = 0128;
 {
 color = 3;
 glyphname = J;
-lastChange = "2022-02-10 16:46:40 +0000";
+lastChange = "2022-02-28 13:29:17 +0000";
 layers = (
 {
 anchors = (
@@ -4363,7 +4237,7 @@ position = "{198, -190}";
 },
 {
 name = top;
-position = "{476, 585}";
+position = "{506, 592}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -4543,7 +4417,7 @@ unicode = 004A;
 },
 {
 glyphname = Jcircumflex;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:29:17 +0000";
 layers = (
 {
 components = (
@@ -4552,7 +4426,7 @@ name = J;
 },
 {
 name = circumflexcomb.case;
-transform = "{1, 0, 0, 1, 476, 285}";
+transform = "{1, 0, 0, 1, 506, 292}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -4835,7 +4709,7 @@ unicode = 0136;
 {
 color = 2;
 glyphname = L;
-lastChange = "2022-02-17 11:40:03 +0000";
+lastChange = "2022-02-28 13:29:32 +0000";
 layers = (
 {
 anchors = (
@@ -4849,7 +4723,7 @@ position = "{304, 123}";
 },
 {
 name = top;
-position = "{553, 585}";
+position = "{593, 625}";
 },
 {
 name = topright;
@@ -5063,7 +4937,7 @@ unicode = 01C7;
 },
 {
 glyphname = Lacute;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:29:32 +0000";
 layers = (
 {
 components = (
@@ -5072,7 +4946,7 @@ name = L;
 },
 {
 name = acutecomb.case;
-transform = "{1, 0, 0, 1, 553, 285}";
+transform = "{1, 0, 0, 1, 593, 325}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -5334,7 +5208,7 @@ unicode = 013F;
 },
 {
 glyphname = Lj;
-lastChange = "2022-02-08 09:17:33 +0000";
+lastChange = "2022-02-28 15:22:46 +0000";
 layers = (
 {
 components = (
@@ -5790,7 +5664,7 @@ unicode = 004D;
 {
 color = 3;
 glyphname = N;
-lastChange = "2022-02-10 16:46:40 +0000";
+lastChange = "2022-02-28 13:30:09 +0000";
 layers = (
 {
 anchors = (
@@ -5800,7 +5674,7 @@ position = "{540, 0}";
 },
 {
 name = top;
-position = "{643, 585}";
+position = "{633, 491}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -5975,7 +5849,7 @@ unicode = 01CA;
 },
 {
 glyphname = Nacute;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:32:19 +0000";
 layers = (
 {
 components = (
@@ -5984,7 +5858,7 @@ name = N;
 },
 {
 name = acutecomb.case;
-transform = "{1, 0, 0, 1, 643, 285}";
+transform = "{1, 0, 0, 1, 633, 191}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -5997,7 +5871,7 @@ unicode = 0143;
 },
 {
 glyphname = Ncaron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:30:09 +0000";
 layers = (
 {
 components = (
@@ -6006,7 +5880,7 @@ name = N;
 },
 {
 name = caroncomb.case;
-transform = "{1, 0, 0, 1, 643, 330}";
+transform = "{1, 0, 0, 1, 633, 191}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6038,50 +5912,6 @@ width = 852;
 leftKerningGroup = N;
 rightKerningGroup = N;
 unicode = 0145;
-},
-{
-glyphname = Nj;
-lastChange = "2022-02-17 09:56:43 +0000";
-layers = (
-{
-components = (
-{
-name = N;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 852, 0}";
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 1007;
-}
-);
-leftKerningGroup = N;
-rightKerningGroup = j;
-unicode = 01CB;
-},
-{
-glyphname = Ntilde;
-lastChange = "2022-02-17 10:37:02 +0000";
-layers = (
-{
-components = (
-{
-name = N;
-},
-{
-name = tildecomb.case;
-transform = "{1, 0, 0, 1, 643, 285}";
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 852;
-}
-);
-leftKerningGroup = N;
-rightKerningGroup = N;
-unicode = 00D1;
 },
 {
 glyphname = Eng;
@@ -6291,9 +6121,53 @@ rightKerningGroup = N;
 unicode = 014A;
 },
 {
+glyphname = Nj;
+lastChange = "2022-02-28 15:00:34 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 852, 0}";
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 1007;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = j;
+unicode = 01CB;
+},
+{
+glyphname = Ntilde;
+lastChange = "2022-02-28 13:32:19 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = tildecomb.case;
+transform = "{1, 0, 0, 1, 633, 191}";
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 852;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = N;
+unicode = 00D1;
+},
+{
 color = 1;
 glyphname = O;
-lastChange = "2022-02-17 10:39:32 +0000";
+lastChange = "2022-02-28 13:34:04 +0000";
 layers = (
 {
 anchors = (
@@ -6315,7 +6189,7 @@ position = "{280, 20}";
 },
 {
 name = top;
-position = "{316, 585}";
+position = "{356, 585}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6466,7 +6340,7 @@ unicode = 004F;
 },
 {
 glyphname = Oacute;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:35:23 +0000";
 layers = (
 {
 components = (
@@ -6475,7 +6349,7 @@ name = O;
 },
 {
 name = acutecomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6488,7 +6362,7 @@ unicode = 00D3;
 },
 {
 glyphname = Obreve;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:35:23 +0000";
 layers = (
 {
 components = (
@@ -6497,7 +6371,7 @@ name = O;
 },
 {
 name = brevecomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6510,7 +6384,7 @@ unicode = 014E;
 },
 {
 glyphname = Ocaron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:35:23 +0000";
 layers = (
 {
 components = (
@@ -6519,7 +6393,7 @@ name = O;
 },
 {
 name = caroncomb.case;
-transform = "{1, 0, 0, 1, 316, 330}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6532,7 +6406,7 @@ unicode = 01D1;
 },
 {
 glyphname = Ocircumflex;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:35:23 +0000";
 layers = (
 {
 components = (
@@ -6541,7 +6415,7 @@ name = O;
 },
 {
 name = circumflexcomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6554,7 +6428,7 @@ unicode = 00D4;
 },
 {
 glyphname = Ocircumflexacute;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:35:23 +0000";
 layers = (
 {
 components = (
@@ -6563,7 +6437,7 @@ name = O;
 },
 {
 name = circumflexcomb_acutecomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6576,7 +6450,7 @@ unicode = 1ED0;
 },
 {
 glyphname = Ocircumflexdotbelow;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:35:23 +0000";
 layers = (
 {
 components = (
@@ -6589,7 +6463,7 @@ transform = "{1, 0, 0, 1, 147, 0}";
 },
 {
 name = circumflexcomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6602,7 +6476,7 @@ unicode = 1ED8;
 },
 {
 glyphname = Ocircumflexgrave;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:35:23 +0000";
 layers = (
 {
 components = (
@@ -6611,7 +6485,7 @@ name = O;
 },
 {
 name = circumflexcomb_gravecomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6624,7 +6498,7 @@ unicode = 1ED2;
 },
 {
 glyphname = Ocircumflexhookabove;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:34:10 +0000";
 layers = (
 {
 components = (
@@ -6633,7 +6507,7 @@ name = O;
 },
 {
 name = circumflexcomb_hookabovecomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6646,7 +6520,7 @@ unicode = 1ED4;
 },
 {
 glyphname = Ocircumflextilde;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:34:09 +0000";
 layers = (
 {
 components = (
@@ -6655,7 +6529,7 @@ name = O;
 },
 {
 name = circumflexcomb_tildecomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6668,7 +6542,7 @@ unicode = 1ED6;
 },
 {
 glyphname = Odblgrave;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:34:09 +0000";
 layers = (
 {
 components = (
@@ -6677,7 +6551,7 @@ name = O;
 },
 {
 name = dblgravecomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6690,7 +6564,7 @@ unicode = 020C;
 },
 {
 glyphname = Odieresis;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:34:04 +0000";
 layers = (
 {
 components = (
@@ -6699,7 +6573,7 @@ name = O;
 },
 {
 name = dieresiscomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6712,7 +6586,7 @@ unicode = 00D6;
 },
 {
 glyphname = Odieresismacron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:34:21 +0000";
 layers = (
 {
 components = (
@@ -6721,11 +6595,12 @@ name = O;
 },
 {
 name = dieresiscomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 },
 {
+alignment = -1;
 name = macroncomb.case;
-transform = "{1, 0, 0, 1, 316, 405}";
+transform = "{1, 0, 0, 1, 366, 365}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6738,7 +6613,7 @@ unicode = 022A;
 },
 {
 glyphname = Odotaccentmacron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:34:31 +0000";
 layers = (
 {
 components = (
@@ -6747,11 +6622,12 @@ name = O;
 },
 {
 name = dotaccentcomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 },
 {
+alignment = -1;
 name = macroncomb.case;
-transform = "{1, 0, 0, 1, 316, 405}";
+transform = "{1, 0, 0, 1, 366, 365}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6786,7 +6662,7 @@ unicode = 1ECC;
 },
 {
 glyphname = Ograve;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:35:19 +0000";
 layers = (
 {
 components = (
@@ -6795,7 +6671,7 @@ name = O;
 },
 {
 name = gravecomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6808,7 +6684,7 @@ unicode = 00D2;
 },
 {
 glyphname = Ohookabove;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:35:23 +0000";
 layers = (
 {
 components = (
@@ -6817,7 +6693,7 @@ name = O;
 },
 {
 name = hookabovecomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6852,7 +6728,7 @@ unicode = 01A0;
 },
 {
 glyphname = Ohornacute;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:35:23 +0000";
 layers = (
 {
 components = (
@@ -6861,7 +6737,7 @@ name = Ohorn;
 },
 {
 name = acutecomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6896,7 +6772,7 @@ unicode = 1EE2;
 },
 {
 glyphname = Ohorngrave;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:35:23 +0000";
 layers = (
 {
 components = (
@@ -6905,7 +6781,7 @@ name = Ohorn;
 },
 {
 name = gravecomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6918,7 +6794,7 @@ unicode = 1EDC;
 },
 {
 glyphname = Ohornhookabove;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:35:23 +0000";
 layers = (
 {
 components = (
@@ -6927,7 +6803,7 @@ name = Ohorn;
 },
 {
 name = hookabovecomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6940,7 +6816,7 @@ unicode = 1EDE;
 },
 {
 glyphname = Ohorntilde;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:35:23 +0000";
 layers = (
 {
 components = (
@@ -6949,7 +6825,7 @@ name = Ohorn;
 },
 {
 name = tildecomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6962,7 +6838,7 @@ unicode = 1EE0;
 },
 {
 glyphname = Ohungarumlaut;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:35:23 +0000";
 layers = (
 {
 components = (
@@ -6971,7 +6847,7 @@ name = O;
 },
 {
 name = hungarumlautcomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -6984,7 +6860,7 @@ unicode = 0150;
 },
 {
 glyphname = Oinvertedbreve;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:35:23 +0000";
 layers = (
 {
 components = (
@@ -6993,7 +6869,7 @@ name = O;
 },
 {
 name = breveinvertedcomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -7006,7 +6882,7 @@ unicode = 020E;
 },
 {
 glyphname = Omacron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:35:23 +0000";
 layers = (
 {
 components = (
@@ -7015,7 +6891,7 @@ name = O;
 },
 {
 name = macroncomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -7051,13 +6927,13 @@ unicode = 01EA;
 {
 color = 3;
 glyphname = Oslash;
-lastChange = "2022-02-10 16:46:40 +0000";
+lastChange = "2022-02-28 13:36:00 +0000";
 layers = (
 {
 anchors = (
 {
 name = top;
-position = "{316, 585}";
+position = "{376, 475}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -7248,7 +7124,7 @@ unicode = 00D8;
 },
 {
 glyphname = Oslashacute;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:38:12 +0000";
 layers = (
 {
 components = (
@@ -7257,7 +7133,7 @@ name = Oslash;
 },
 {
 name = acutecomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 376, 175}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -7270,7 +7146,7 @@ unicode = 01FE;
 },
 {
 glyphname = Otilde;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:35:23 +0000";
 layers = (
 {
 components = (
@@ -7279,7 +7155,7 @@ name = O;
 },
 {
 name = tildecomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -7292,7 +7168,7 @@ unicode = 00D5;
 },
 {
 glyphname = Otildemacron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:35:23 +0000";
 layers = (
 {
 components = (
@@ -7301,7 +7177,7 @@ name = O;
 },
 {
 name = tildecomb_macroncomb.case;
-transform = "{1, 0, 0, 1, 316, 285}";
+transform = "{1, 0, 0, 1, 356, 285}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -8043,7 +7919,7 @@ unicode = 0051;
 {
 color = 3;
 glyphname = R;
-lastChange = "2022-02-10 16:46:40 +0000";
+lastChange = "2022-02-28 13:38:37 +0000";
 layers = (
 {
 anchors = (
@@ -8053,7 +7929,7 @@ position = "{448, 0}";
 },
 {
 name = top;
-position = "{508, 585}";
+position = "{528, 565}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -8339,7 +8215,7 @@ unicode = 0052;
 },
 {
 glyphname = Racute;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:38:52 +0000";
 layers = (
 {
 components = (
@@ -8348,7 +8224,7 @@ name = R;
 },
 {
 name = acutecomb.case;
-transform = "{1, 0, 0, 1, 508, 285}";
+transform = "{1, 0, 0, 1, 528, 265}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -8361,7 +8237,7 @@ unicode = 0154;
 },
 {
 glyphname = Rcaron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:38:37 +0000";
 layers = (
 {
 components = (
@@ -8370,7 +8246,7 @@ name = R;
 },
 {
 name = caroncomb.case;
-transform = "{1, 0, 0, 1, 508, 330}";
+transform = "{1, 0, 0, 1, 528, 265}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -8405,7 +8281,7 @@ unicode = 0156;
 },
 {
 glyphname = Rdblgrave;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:38:52 +0000";
 layers = (
 {
 components = (
@@ -8414,7 +8290,7 @@ name = R;
 },
 {
 name = dblgravecomb.case;
-transform = "{1, 0, 0, 1, 508, 285}";
+transform = "{1, 0, 0, 1, 528, 265}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -8427,7 +8303,7 @@ unicode = 0210;
 },
 {
 glyphname = Rinvertedbreve;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:38:52 +0000";
 layers = (
 {
 components = (
@@ -8436,7 +8312,7 @@ name = R;
 },
 {
 name = breveinvertedcomb.case;
-transform = "{1, 0, 0, 1, 508, 285}";
+transform = "{1, 0, 0, 1, 528, 265}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -8450,7 +8326,7 @@ unicode = 0212;
 {
 color = 3;
 glyphname = S;
-lastChange = "2022-02-10 16:46:40 +0000";
+lastChange = "2022-02-28 13:40:02 +0000";
 layers = (
 {
 anchors = (
@@ -8464,7 +8340,7 @@ position = "{99, -98}";
 },
 {
 name = top;
-position = "{287, 585}";
+position = "{294, 553}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -8620,7 +8496,7 @@ unicode = 0053;
 },
 {
 glyphname = Sacute;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:43:15 +0000";
 layers = (
 {
 components = (
@@ -8629,7 +8505,7 @@ name = S;
 },
 {
 name = acutecomb.case;
-transform = "{1, 0, 0, 1, 287, 285}";
+transform = "{1, 0, 0, 1, 294, 253}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -8642,7 +8518,7 @@ unicode = 015A;
 },
 {
 glyphname = Scaron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:40:02 +0000";
 layers = (
 {
 components = (
@@ -8651,7 +8527,7 @@ name = S;
 },
 {
 name = caroncomb.case;
-transform = "{1, 0, 0, 1, 287, 330}";
+transform = "{1, 0, 0, 1, 294, 253}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -8686,7 +8562,7 @@ unicode = 015E;
 },
 {
 glyphname = Scircumflex;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:40:06 +0000";
 layers = (
 {
 components = (
@@ -8695,7 +8571,7 @@ name = S;
 },
 {
 name = circumflexcomb.case;
-transform = "{1, 0, 0, 1, 287, 285}";
+transform = "{1, 0, 0, 1, 294, 253}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -8845,9 +8721,143 @@ rightKerningGroup = Germ;
 unicode = 1E9E;
 },
 {
+glyphname = Schwa;
+lastChange = "2022-02-07 21:15:03 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"94 549 OFFCURVE",
+"89 540 OFFCURVE",
+"89 532 CURVE SMOOTH",
+"89 526 OFFCURVE",
+"93 522 OFFCURVE",
+"99 522 CURVE SMOOTH",
+"104 522 OFFCURVE",
+"112 526 OFFCURVE",
+"121 534 CURVE SMOOTH",
+"143 554 OFFCURVE",
+"204 586 OFFCURVE",
+"235 594 CURVE SMOOTH",
+"262 602 OFFCURVE",
+"289 606 OFFCURVE",
+"322 606 CURVE SMOOTH",
+"331 606 OFFCURVE",
+"341 606 OFFCURVE",
+"351 605 CURVE SMOOTH",
+"417 601 OFFCURVE",
+"455 552 OFFCURVE",
+"494 515 CURVE SMOOTH",
+"528 482 OFFCURVE",
+"540 445 OFFCURVE",
+"540 390 CURVE SMOOTH",
+"540 365 OFFCURVE",
+"537 337 OFFCURVE",
+"533 304 CURVE SMOOTH",
+"527 261 OFFCURVE",
+"507 197 OFFCURVE",
+"492 169 CURVE SMOOTH",
+"461 113 OFFCURVE",
+"425 56 OFFCURVE",
+"368 24 CURVE SMOOTH",
+"337 7 OFFCURVE",
+"298 -18 OFFCURVE",
+"235 -18 CURVE SMOOTH",
+"222 -18 OFFCURVE",
+"208 -17 OFFCURVE",
+"193 -15 CURVE SMOOTH",
+"140 -5 OFFCURVE",
+"114 12 OFFCURVE",
+"95 49 CURVE SMOOTH",
+"89 60 OFFCURVE",
+"85 76 OFFCURVE",
+"85 95 CURVE SMOOTH",
+"85 112 OFFCURVE",
+"88 131 OFFCURVE",
+"97 149 CURVE SMOOTH",
+"123 205 OFFCURVE",
+"212 277 OFFCURVE",
+"320 300 CURVE SMOOTH",
+"371 298 OFFCURVE",
+"393 298 OFFCURVE",
+"438 283 CURVE SMOOTH",
+"476 268 OFFCURVE",
+"493 240 OFFCURVE",
+"498 231 CURVE SMOOTH",
+"507 220 OFFCURVE",
+"520 214 OFFCURVE",
+"530 214 CURVE SMOOTH",
+"539 214 OFFCURVE",
+"545 218 OFFCURVE",
+"545 226 CURVE SMOOTH",
+"545 230 OFFCURVE",
+"543 236 OFFCURVE",
+"538 243 CURVE SMOOTH",
+"529 254 OFFCURVE",
+"507 299 OFFCURVE",
+"458 314 CURVE SMOOTH",
+"412 330 OFFCURVE",
+"400 334 OFFCURVE",
+"363 334 CURVE SMOOTH",
+"354 334 OFFCURVE",
+"342 333 OFFCURVE",
+"328 333 CURVE SMOOTH",
+"129 325 OFFCURVE",
+"101 232 OFFCURVE",
+"70 162 CURVE SMOOTH",
+"60 139 OFFCURVE",
+"56 116 OFFCURVE",
+"56 94 CURVE SMOOTH",
+"56 68 OFFCURVE",
+"61 45 OFFCURVE",
+"70 29 CURVE SMOOTH",
+"92 -13 OFFCURVE",
+"138 -59 OFFCURVE",
+"202 -69 CURVE SMOOTH",
+"221 -72 OFFCURVE",
+"238 -74 OFFCURVE",
+"253 -74 CURVE SMOOTH",
+"319 -74 OFFCURVE",
+"361 -48 OFFCURVE",
+"393 -29 CURVE SMOOTH",
+"455 7 OFFCURVE",
+"497 70 OFFCURVE",
+"529 130 CURVE SMOOTH",
+"546 162 OFFCURVE",
+"570 231 OFFCURVE",
+"575 279 CURVE SMOOTH",
+"578 303 OFFCURVE",
+"580 327 OFFCURVE",
+"580 349 CURVE SMOOTH",
+"580 431 OFFCURVE",
+"557 497 OFFCURVE",
+"515 540 CURVE SMOOTH",
+"475 579 OFFCURVE",
+"430 633 OFFCURVE",
+"355 637 CURVE SMOOTH",
+"303 640 OFFCURVE",
+"268 635 OFFCURVE",
+"230 625 CURVE SMOOTH",
+"197 617 OFFCURVE",
+"128 581 OFFCURVE",
+"104 559 CURVE SMOOTH"
+);
+}
+);
+width = 592;
+}
+);
+leftKerningGroup = Schwa;
+rightKerningGroup = O;
+unicode = 018F;
+},
+{
 color = 1;
 glyphname = T;
-lastChange = "2022-02-17 11:39:33 +0000";
+lastChange = "2022-02-28 14:08:14 +0000";
 layers = (
 {
 anchors = (
@@ -8865,7 +8875,7 @@ position = "{385, 350}";
 },
 {
 name = top;
-position = "{454, 545}";
+position = "{454, 555}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9043,7 +9053,7 @@ unicode = 0166;
 },
 {
 glyphname = Tcaron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 14:08:14 +0000";
 layers = (
 {
 components = (
@@ -9052,7 +9062,7 @@ name = T;
 },
 {
 name = caroncomb.case;
-transform = "{1, 0, 0, 1, 454, 290}";
+transform = "{1, 0, 0, 1, 454, 255}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9110,7 +9120,7 @@ unicode = 021A;
 {
 color = 1;
 glyphname = U;
-lastChange = "2022-02-17 10:39:32 +0000";
+lastChange = "2022-02-28 13:40:29 +0000";
 layers = (
 {
 anchors = (
@@ -9128,7 +9138,7 @@ position = "{645, -28}";
 },
 {
 name = top;
-position = "{673, 585}";
+position = "{643, 505}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9311,7 +9321,7 @@ unicode = 0055;
 },
 {
 glyphname = Uacute;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:43:15 +0000";
 layers = (
 {
 components = (
@@ -9320,7 +9330,7 @@ name = U;
 },
 {
 name = acutecomb.case;
-transform = "{1, 0, 0, 1, 673, 285}";
+transform = "{1, 0, 0, 1, 643, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9333,7 +9343,7 @@ unicode = 00DA;
 },
 {
 glyphname = Ubreve;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:43:15 +0000";
 layers = (
 {
 components = (
@@ -9342,7 +9352,7 @@ name = U;
 },
 {
 name = brevecomb.case;
-transform = "{1, 0, 0, 1, 673, 285}";
+transform = "{1, 0, 0, 1, 643, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9355,7 +9365,7 @@ unicode = 016C;
 },
 {
 glyphname = Ucaron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:40:29 +0000";
 layers = (
 {
 components = (
@@ -9364,7 +9374,7 @@ name = U;
 },
 {
 name = caroncomb.case;
-transform = "{1, 0, 0, 1, 673, 330}";
+transform = "{1, 0, 0, 1, 643, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9377,7 +9387,7 @@ unicode = 01D3;
 },
 {
 glyphname = Ucircumflex;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:40:31 +0000";
 layers = (
 {
 components = (
@@ -9386,7 +9396,7 @@ name = U;
 },
 {
 name = circumflexcomb.case;
-transform = "{1, 0, 0, 1, 673, 285}";
+transform = "{1, 0, 0, 1, 643, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9399,7 +9409,7 @@ unicode = 00DB;
 },
 {
 glyphname = Udblgrave;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:40:32 +0000";
 layers = (
 {
 components = (
@@ -9408,7 +9418,7 @@ name = U;
 },
 {
 name = dblgravecomb.case;
-transform = "{1, 0, 0, 1, 673, 285}";
+transform = "{1, 0, 0, 1, 643, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9421,7 +9431,7 @@ unicode = 0214;
 },
 {
 glyphname = Udieresis;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:40:32 +0000";
 layers = (
 {
 components = (
@@ -9430,7 +9440,7 @@ name = U;
 },
 {
 name = dieresiscomb.case;
-transform = "{1, 0, 0, 1, 673, 285}";
+transform = "{1, 0, 0, 1, 643, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9444,7 +9454,7 @@ unicode = 00DC;
 {
 color = 9;
 glyphname = Udieresiscaron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:40:56 +0000";
 layers = (
 {
 components = (
@@ -9453,12 +9463,12 @@ name = U;
 },
 {
 name = dieresiscomb.case;
-transform = "{1, 0, 0, 1, 673, 285}";
+transform = "{1, 0, 0, 1, 643, 205}";
 },
 {
 alignment = -1;
 name = caroncomb.case;
-transform = "{1, 0, 0, 1, 673, 420}";
+transform = "{1, 0, 0, 1, 663, 315}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9472,7 +9482,7 @@ unicode = 01D9;
 {
 color = 9;
 glyphname = Udieresisgrave;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:41:04 +0000";
 layers = (
 {
 components = (
@@ -9481,12 +9491,12 @@ name = U;
 },
 {
 name = dieresiscomb.case;
-transform = "{1, 0, 0, 1, 673, 285}";
+transform = "{1, 0, 0, 1, 643, 205}";
 },
 {
 alignment = -1;
 name = gravecomb.case;
-transform = "{1, 0, 0, 1, 673, 420}";
+transform = "{1, 0, 0, 1, 663, 315}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9500,7 +9510,7 @@ unicode = 01DB;
 {
 color = 9;
 glyphname = Udieresismacron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:41:28 +0000";
 layers = (
 {
 components = (
@@ -9509,12 +9519,12 @@ name = U;
 },
 {
 name = dieresiscomb.case;
-transform = "{1, 0, 0, 1, 673, 285}";
+transform = "{1, 0, 0, 1, 643, 205}";
 },
 {
 alignment = -1;
 name = macroncomb.case;
-transform = "{1, 0, 0, 1, 683, 420}";
+transform = "{1, 0, 0, 1, 663, 295}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9549,7 +9559,7 @@ unicode = 1EE4;
 },
 {
 glyphname = Ugrave;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:41:31 +0000";
 layers = (
 {
 components = (
@@ -9558,7 +9568,7 @@ name = U;
 },
 {
 name = gravecomb.case;
-transform = "{1, 0, 0, 1, 673, 285}";
+transform = "{1, 0, 0, 1, 643, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9571,7 +9581,7 @@ unicode = 00D9;
 },
 {
 glyphname = Uhookabove;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:41:32 +0000";
 layers = (
 {
 components = (
@@ -9580,7 +9590,7 @@ name = U;
 },
 {
 name = hookabovecomb.case;
-transform = "{1, 0, 0, 1, 673, 285}";
+transform = "{1, 0, 0, 1, 643, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9615,7 +9625,7 @@ unicode = 01AF;
 },
 {
 glyphname = Uhornacute;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:41:35 +0000";
 layers = (
 {
 components = (
@@ -9624,7 +9634,7 @@ name = Uhorn;
 },
 {
 name = acutecomb.case;
-transform = "{1, 0, 0, 1, 673, 285}";
+transform = "{1, 0, 0, 1, 643, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9659,7 +9669,7 @@ unicode = 1EF0;
 },
 {
 glyphname = Uhorngrave;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:41:37 +0000";
 layers = (
 {
 components = (
@@ -9668,7 +9678,7 @@ name = Uhorn;
 },
 {
 name = gravecomb.case;
-transform = "{1, 0, 0, 1, 673, 285}";
+transform = "{1, 0, 0, 1, 643, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9681,7 +9691,7 @@ unicode = 1EEA;
 },
 {
 glyphname = Uhornhookabove;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:41:37 +0000";
 layers = (
 {
 components = (
@@ -9690,7 +9700,7 @@ name = Uhorn;
 },
 {
 name = hookabovecomb.case;
-transform = "{1, 0, 0, 1, 673, 285}";
+transform = "{1, 0, 0, 1, 643, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9703,7 +9713,7 @@ unicode = 1EEC;
 },
 {
 glyphname = Uhorntilde;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:41:38 +0000";
 layers = (
 {
 components = (
@@ -9712,7 +9722,7 @@ name = Uhorn;
 },
 {
 name = tildecomb.case;
-transform = "{1, 0, 0, 1, 673, 285}";
+transform = "{1, 0, 0, 1, 643, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9725,7 +9735,7 @@ unicode = 1EEE;
 },
 {
 glyphname = Uhungarumlaut;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:41:39 +0000";
 layers = (
 {
 components = (
@@ -9734,7 +9744,7 @@ name = U;
 },
 {
 name = hungarumlautcomb.case;
-transform = "{1, 0, 0, 1, 673, 285}";
+transform = "{1, 0, 0, 1, 643, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9747,7 +9757,7 @@ unicode = 0170;
 },
 {
 glyphname = Uinvertedbreve;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:41:41 +0000";
 layers = (
 {
 components = (
@@ -9756,7 +9766,7 @@ name = U;
 },
 {
 name = breveinvertedcomb.case;
-transform = "{1, 0, 0, 1, 673, 285}";
+transform = "{1, 0, 0, 1, 643, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9769,7 +9779,7 @@ unicode = 0216;
 },
 {
 glyphname = Umacron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:41:41 +0000";
 layers = (
 {
 components = (
@@ -9778,7 +9788,7 @@ name = U;
 },
 {
 name = macroncomb.case;
-transform = "{1, 0, 0, 1, 673, 285}";
+transform = "{1, 0, 0, 1, 643, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9813,7 +9823,7 @@ unicode = 0172;
 },
 {
 glyphname = Uring;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:41:42 +0000";
 layers = (
 {
 components = (
@@ -9822,7 +9832,7 @@ name = U;
 },
 {
 name = ringcomb.case;
-transform = "{1, 0, 0, 1, 673, 285}";
+transform = "{1, 0, 0, 1, 643, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -9835,7 +9845,7 @@ unicode = 016E;
 },
 {
 glyphname = Utilde;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:41:44 +0000";
 layers = (
 {
 components = (
@@ -9844,7 +9854,7 @@ name = U;
 },
 {
 name = tildecomb.case;
-transform = "{1, 0, 0, 1, 673, 285}";
+transform = "{1, 0, 0, 1, 643, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -10481,17 +10491,17 @@ unicode = 0058;
 {
 color = 1;
 glyphname = Y;
-lastChange = "2022-02-17 10:39:32 +0000";
+lastChange = "2022-02-28 13:42:52 +0000";
 layers = (
 {
 anchors = (
 {
 name = bottom;
-position = "{641, 0}";
+position = "{651, 0}";
 },
 {
 name = top;
-position = "{618, 585}";
+position = "{618, 505}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -10715,7 +10725,7 @@ unicode = 0059;
 },
 {
 glyphname = Yacute;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:42:17 +0000";
 layers = (
 {
 components = (
@@ -10724,7 +10734,7 @@ name = Y;
 },
 {
 name = acutecomb.case;
-transform = "{1, 0, 0, 1, 618, 285}";
+transform = "{1, 0, 0, 1, 618, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -10737,7 +10747,7 @@ unicode = 00DD;
 },
 {
 glyphname = Ycircumflex;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:42:19 +0000";
 layers = (
 {
 components = (
@@ -10746,7 +10756,7 @@ name = Y;
 },
 {
 name = circumflexcomb.case;
-transform = "{1, 0, 0, 1, 618, 285}";
+transform = "{1, 0, 0, 1, 618, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -10759,7 +10769,7 @@ unicode = 0176;
 },
 {
 glyphname = Ydieresis;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:42:20 +0000";
 layers = (
 {
 components = (
@@ -10768,7 +10778,7 @@ name = Y;
 },
 {
 name = dieresiscomb.case;
-transform = "{1, 0, 0, 1, 618, 285}";
+transform = "{1, 0, 0, 1, 618, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -10781,7 +10791,7 @@ unicode = 0178;
 },
 {
 glyphname = Ydotbelow;
-lastChange = "2022-02-17 10:39:29 +0000";
+lastChange = "2022-02-28 13:42:52 +0000";
 layers = (
 {
 components = (
@@ -10790,7 +10800,7 @@ name = Y;
 },
 {
 name = dotbelowcomb.case;
-transform = "{1, 0, 0, 1, 641, 0}";
+transform = "{1, 0, 0, 1, 651, 0}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -10803,7 +10813,7 @@ unicode = 1EF4;
 },
 {
 glyphname = Ygrave;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:42:48 +0000";
 layers = (
 {
 components = (
@@ -10812,7 +10822,7 @@ name = Y;
 },
 {
 name = gravecomb.case;
-transform = "{1, 0, 0, 1, 618, 285}";
+transform = "{1, 0, 0, 1, 618, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -10825,7 +10835,7 @@ unicode = 1EF2;
 },
 {
 glyphname = Yhookabove;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:42:56 +0000";
 layers = (
 {
 components = (
@@ -10834,7 +10844,7 @@ name = Y;
 },
 {
 name = hookabovecomb.case;
-transform = "{1, 0, 0, 1, 618, 285}";
+transform = "{1, 0, 0, 1, 618, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -10847,7 +10857,7 @@ unicode = 1EF6;
 },
 {
 glyphname = Ymacron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:42:56 +0000";
 layers = (
 {
 components = (
@@ -10856,7 +10866,7 @@ name = Y;
 },
 {
 name = macroncomb.case;
-transform = "{1, 0, 0, 1, 618, 285}";
+transform = "{1, 0, 0, 1, 618, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -10869,7 +10879,7 @@ unicode = 0232;
 },
 {
 glyphname = Ytilde;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:42:57 +0000";
 layers = (
 {
 components = (
@@ -10878,7 +10888,7 @@ name = Y;
 },
 {
 name = tildecomb.case;
-transform = "{1, 0, 0, 1, 618, 285}";
+transform = "{1, 0, 0, 1, 618, 205}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -10892,7 +10902,7 @@ unicode = 1EF8;
 {
 color = 1;
 glyphname = Z;
-lastChange = "2022-02-17 10:39:32 +0000";
+lastChange = "2022-02-28 13:43:13 +0000";
 layers = (
 {
 anchors = (
@@ -10906,7 +10916,7 @@ position = "{248, 320}";
 },
 {
 name = top;
-position = "{388, 585}";
+position = "{383, 545}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -11053,7 +11063,7 @@ unicode = 005A;
 },
 {
 glyphname = Zacute;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:43:15 +0000";
 layers = (
 {
 components = (
@@ -11062,7 +11072,7 @@ name = Z;
 },
 {
 name = acutecomb.case;
-transform = "{1, 0, 0, 1, 388, 285}";
+transform = "{1, 0, 0, 1, 383, 245}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -11075,7 +11085,7 @@ unicode = 0179;
 },
 {
 glyphname = Zcaron;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:43:13 +0000";
 layers = (
 {
 components = (
@@ -11084,7 +11094,7 @@ name = Z;
 },
 {
 name = caroncomb.case;
-transform = "{1, 0, 0, 1, 388, 330}";
+transform = "{1, 0, 0, 1, 383, 245}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -11097,7 +11107,7 @@ unicode = 017D;
 },
 {
 glyphname = Zdotaccent;
-lastChange = "2022-02-17 10:37:02 +0000";
+lastChange = "2022-02-28 13:43:15 +0000";
 layers = (
 {
 components = (
@@ -11106,7 +11116,7 @@ name = Z;
 },
 {
 name = dotaccentcomb.case;
-transform = "{1, 0, 0, 1, 388, 285}";
+transform = "{1, 0, 0, 1, 383, 245}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -11797,7 +11807,7 @@ unicode = 00E3;
 {
 color = 3;
 glyphname = ae;
-lastChange = "2022-02-08 09:58:48 +0000";
+lastChange = "2022-02-28 14:05:14 +0000";
 layers = (
 {
 anchors = (
@@ -11807,7 +11817,7 @@ position = "{173, 0}";
 },
 {
 name = top;
-position = "{183, 300}";
+position = "{177, 255}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -11949,7 +11959,7 @@ unicode = 00E6;
 },
 {
 glyphname = aeacute;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 14:05:14 +0000";
 layers = (
 {
 components = (
@@ -11958,7 +11968,7 @@ name = ae;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 183, 0}";
+transform = "{1, 0, 0, 1, 177, -45}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -12082,7 +12092,7 @@ unicode = 0062;
 {
 color = 1;
 glyphname = c;
-lastChange = "2022-02-17 09:48:59 +0000";
+lastChange = "2022-02-28 12:17:32 +0000";
 layers = (
 {
 anchors = (
@@ -12096,7 +12106,7 @@ position = "{77, 13}";
 },
 {
 name = top;
-position = "{137, 255}";
+position = "{137, 245}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -12183,7 +12193,7 @@ unicode = 0063;
 },
 {
 glyphname = cacute;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:19:32 +0000";
 layers = (
 {
 components = (
@@ -12192,7 +12202,7 @@ name = c;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 137, -45}";
+transform = "{1, 0, 0, 1, 137, -55}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -12205,7 +12215,7 @@ unicode = 0107;
 },
 {
 glyphname = ccaron;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:17:32 +0000";
 layers = (
 {
 components = (
@@ -12214,7 +12224,7 @@ name = c;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 137, -45}";
+transform = "{1, 0, 0, 1, 137, -55}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -12249,7 +12259,7 @@ unicode = 00E7;
 },
 {
 glyphname = ccircumflex;
-lastChange = "2022-02-17 10:53:35 +0000";
+lastChange = "2022-02-28 12:19:32 +0000";
 layers = (
 {
 components = (
@@ -12258,7 +12268,7 @@ name = c;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 137, -45}";
+transform = "{1, 0, 0, 1, 137, -55}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -12271,7 +12281,7 @@ unicode = 0109;
 },
 {
 glyphname = cdotaccent;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:19:32 +0000";
 layers = (
 {
 components = (
@@ -12280,7 +12290,7 @@ name = c;
 },
 {
 name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 137, -45}";
+transform = "{1, 0, 0, 1, 137, -55}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -12560,7 +12570,7 @@ unicode = 010F;
 },
 {
 glyphname = dcroat;
-lastChange = "2022-02-08 10:29:17 +0000";
+lastChange = "2022-02-28 14:36:50 +0000";
 layers = (
 {
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -12745,7 +12755,7 @@ unicode = 01C6;
 {
 color = 3;
 glyphname = e;
-lastChange = "2022-02-17 10:55:35 +0000";
+lastChange = "2022-02-28 14:09:07 +0000";
 layers = (
 {
 anchors = (
@@ -12759,7 +12769,7 @@ position = "{155, 33}";
 },
 {
 name = top;
-position = "{122, 275}";
+position = "{122, 260}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -12845,7 +12855,7 @@ unicode = 0065;
 },
 {
 glyphname = eacute;
-lastChange = "2022-02-17 10:54:17 +0000";
+lastChange = "2022-02-28 14:18:07 +0000";
 layers = (
 {
 components = (
@@ -12854,7 +12864,7 @@ name = e;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 122, -25}";
+transform = "{1, 0, 0, 1, 122, -40}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -12867,7 +12877,7 @@ unicode = 00E9;
 },
 {
 glyphname = ebreve;
-lastChange = "2022-02-17 10:54:17 +0000";
+lastChange = "2022-02-28 14:18:07 +0000";
 layers = (
 {
 components = (
@@ -12876,7 +12886,7 @@ name = e;
 },
 {
 name = brevecomb;
-transform = "{1, 0, 0, 1, 122, -25}";
+transform = "{1, 0, 0, 1, 122, -40}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -12889,7 +12899,7 @@ unicode = 0115;
 },
 {
 glyphname = ecaron;
-lastChange = "2022-02-17 10:54:17 +0000";
+lastChange = "2022-02-28 14:18:07 +0000";
 layers = (
 {
 components = (
@@ -12898,7 +12908,7 @@ name = e;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 122, -25}";
+transform = "{1, 0, 0, 1, 122, -40}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -12911,7 +12921,7 @@ unicode = 011B;
 },
 {
 glyphname = ecircumflex;
-lastChange = "2022-02-17 10:55:46 +0000";
+lastChange = "2022-02-28 14:09:07 +0000";
 layers = (
 {
 components = (
@@ -12920,7 +12930,7 @@ name = e;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 122, -25}";
+transform = "{1, 0, 0, 1, 122, -40}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -12933,7 +12943,7 @@ unicode = 00EA;
 },
 {
 glyphname = ecircumflexacute;
-lastChange = "2022-02-17 10:54:12 +0000";
+lastChange = "2022-02-28 14:09:13 +0000";
 layers = (
 {
 components = (
@@ -12942,7 +12952,7 @@ name = e;
 },
 {
 name = circumflexcomb_acutecomb;
-transform = "{1, 0, 0, 1, 122, -25}";
+transform = "{1, 0, 0, 1, 122, -40}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -12955,7 +12965,7 @@ unicode = 1EBF;
 },
 {
 glyphname = ecircumflexdotbelow;
-lastChange = "2022-02-17 10:54:17 +0000";
+lastChange = "2022-02-28 14:09:13 +0000";
 layers = (
 {
 components = (
@@ -12968,7 +12978,7 @@ transform = "{1, 0, 0, 1, 90, 23}";
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 122, -25}";
+transform = "{1, 0, 0, 1, 122, -40}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -12981,7 +12991,7 @@ unicode = 1EC7;
 },
 {
 glyphname = ecircumflexgrave;
-lastChange = "2022-02-17 10:54:15 +0000";
+lastChange = "2022-02-28 14:09:13 +0000";
 layers = (
 {
 components = (
@@ -12990,7 +13000,7 @@ name = e;
 },
 {
 name = circumflexcomb_gravecomb;
-transform = "{1, 0, 0, 1, 122, -25}";
+transform = "{1, 0, 0, 1, 122, -40}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -13003,7 +13013,7 @@ unicode = 1EC1;
 },
 {
 glyphname = ecircumflexhookabove;
-lastChange = "2022-02-17 10:54:15 +0000";
+lastChange = "2022-02-28 14:09:14 +0000";
 layers = (
 {
 components = (
@@ -13012,7 +13022,7 @@ name = e;
 },
 {
 name = circumflexcomb_hookabovecomb;
-transform = "{1, 0, 0, 1, 122, -25}";
+transform = "{1, 0, 0, 1, 122, -40}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -13025,7 +13035,7 @@ unicode = 1EC3;
 },
 {
 glyphname = ecircumflextilde;
-lastChange = "2022-02-17 10:54:15 +0000";
+lastChange = "2022-02-28 14:09:14 +0000";
 layers = (
 {
 components = (
@@ -13034,7 +13044,7 @@ name = e;
 },
 {
 name = circumflexcomb_tildecomb;
-transform = "{1, 0, 0, 1, 122, -25}";
+transform = "{1, 0, 0, 1, 122, -40}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -13047,7 +13057,7 @@ unicode = 1EC5;
 },
 {
 glyphname = edblgrave;
-lastChange = "2022-02-17 10:54:17 +0000";
+lastChange = "2022-02-28 14:09:15 +0000";
 layers = (
 {
 components = (
@@ -13056,7 +13066,7 @@ name = e;
 },
 {
 name = dblgravecomb;
-transform = "{1, 0, 0, 1, 122, -25}";
+transform = "{1, 0, 0, 1, 122, -40}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -13069,7 +13079,7 @@ unicode = 0205;
 },
 {
 glyphname = edieresis;
-lastChange = "2022-02-17 10:54:17 +0000";
+lastChange = "2022-02-28 14:18:07 +0000";
 layers = (
 {
 components = (
@@ -13078,7 +13088,7 @@ name = e;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 122, -25}";
+transform = "{1, 0, 0, 1, 122, -40}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -13091,7 +13101,7 @@ unicode = 00EB;
 },
 {
 glyphname = edotaccent;
-lastChange = "2022-02-17 10:54:17 +0000";
+lastChange = "2022-02-28 14:18:07 +0000";
 layers = (
 {
 components = (
@@ -13100,7 +13110,7 @@ name = e;
 },
 {
 name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 122, -25}";
+transform = "{1, 0, 0, 1, 122, -40}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -13135,7 +13145,7 @@ unicode = 1EB9;
 },
 {
 glyphname = egrave;
-lastChange = "2022-02-17 10:54:17 +0000";
+lastChange = "2022-02-28 14:18:07 +0000";
 layers = (
 {
 components = (
@@ -13144,7 +13154,7 @@ name = e;
 },
 {
 name = gravecomb;
-transform = "{1, 0, 0, 1, 122, -25}";
+transform = "{1, 0, 0, 1, 122, -40}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -13157,7 +13167,7 @@ unicode = 00E8;
 },
 {
 glyphname = ehookabove;
-lastChange = "2022-02-17 10:54:17 +0000";
+lastChange = "2022-02-28 14:18:07 +0000";
 layers = (
 {
 components = (
@@ -13166,7 +13176,7 @@ name = e;
 },
 {
 name = hookabovecomb;
-transform = "{1, 0, 0, 1, 122, -25}";
+transform = "{1, 0, 0, 1, 122, -40}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -13179,7 +13189,7 @@ unicode = 1EBB;
 },
 {
 glyphname = einvertedbreve;
-lastChange = "2022-02-17 10:54:17 +0000";
+lastChange = "2022-02-28 14:18:07 +0000";
 layers = (
 {
 components = (
@@ -13188,7 +13198,7 @@ name = e;
 },
 {
 name = breveinvertedcomb;
-transform = "{1, 0, 0, 1, 122, -25}";
+transform = "{1, 0, 0, 1, 122, -40}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -13201,7 +13211,7 @@ unicode = 0207;
 },
 {
 glyphname = emacron;
-lastChange = "2022-02-17 10:54:17 +0000";
+lastChange = "2022-02-28 14:18:07 +0000";
 layers = (
 {
 components = (
@@ -13210,7 +13220,7 @@ name = e;
 },
 {
 name = macroncomb;
-transform = "{1, 0, 0, 1, 122, -25}";
+transform = "{1, 0, 0, 1, 122, -40}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -13245,7 +13255,7 @@ unicode = 0119;
 },
 {
 glyphname = etilde;
-lastChange = "2022-02-17 10:54:17 +0000";
+lastChange = "2022-02-28 14:18:07 +0000";
 layers = (
 {
 components = (
@@ -13254,7 +13264,7 @@ name = e;
 },
 {
 name = tildecomb;
-transform = "{1, 0, 0, 1, 122, -25}";
+transform = "{1, 0, 0, 1, 122, -40}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -13491,7 +13501,7 @@ unicode = 0066;
 {
 color = 3;
 glyphname = g;
-lastChange = "2022-02-08 12:56:30 +0000";
+lastChange = "2022-02-28 12:21:11 +0000";
 layers = (
 {
 anchors = (
@@ -13501,7 +13511,7 @@ position = "{36, -250}";
 },
 {
 name = top;
-position = "{216, 300}";
+position = "{233, 281}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -13668,7 +13678,7 @@ unicode = 0067;
 },
 {
 glyphname = gbreve;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:21:13 +0000";
 layers = (
 {
 components = (
@@ -13677,7 +13687,7 @@ name = g;
 },
 {
 name = brevecomb;
-transform = "{1, 0, 0, 1, 216, 0}";
+transform = "{1, 0, 0, 1, 233, -19}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -13690,7 +13700,7 @@ unicode = 011F;
 },
 {
 glyphname = gcaron;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:21:11 +0000";
 layers = (
 {
 components = (
@@ -13699,7 +13709,7 @@ name = g;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 216, 0}";
+transform = "{1, 0, 0, 1, 233, -19}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -13712,7 +13722,7 @@ unicode = 01E7;
 },
 {
 glyphname = gcircumflex;
-lastChange = "2022-02-17 10:53:35 +0000";
+lastChange = "2022-02-28 12:21:13 +0000";
 layers = (
 {
 components = (
@@ -13721,7 +13731,7 @@ name = g;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 216, 0}";
+transform = "{1, 0, 0, 1, 233, -19}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -13734,7 +13744,7 @@ unicode = 011D;
 },
 {
 glyphname = gcommaaccent;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:21:13 +0000";
 layers = (
 {
 components = (
@@ -13743,7 +13753,7 @@ name = g;
 },
 {
 name = commaturnedabovecomb;
-transform = "{1, 0, 0, 1, 216, 0}";
+transform = "{1, 0, 0, 1, 233, -19}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -13756,7 +13766,7 @@ unicode = 0123;
 },
 {
 glyphname = gdotaccent;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:21:13 +0000";
 layers = (
 {
 components = (
@@ -13765,7 +13775,7 @@ name = g;
 },
 {
 name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 216, 0}";
+transform = "{1, 0, 0, 1, 233, -19}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -13779,7 +13789,7 @@ unicode = 0121;
 {
 color = 3;
 glyphname = h;
-lastChange = "2022-02-08 20:18:08 +0000";
+lastChange = "2022-02-28 12:21:23 +0000";
 layers = (
 {
 anchors = (
@@ -13931,7 +13941,7 @@ unicode = 0127;
 },
 {
 glyphname = hcircumflex;
-lastChange = "2022-02-17 10:53:35 +0000";
+lastChange = "2022-02-28 12:21:33 +0000";
 layers = (
 {
 components = (
@@ -14068,7 +14078,7 @@ unicode = 0069;
 {
 color = 3;
 glyphname = idotless;
-lastChange = "2022-02-17 09:49:43 +0000";
+lastChange = "2022-02-28 12:23:01 +0000";
 layers = (
 {
 anchors = (
@@ -14082,7 +14092,7 @@ position = "{150, 28}";
 },
 {
 name = top;
-position = "{201, 300}";
+position = "{189, 297}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -14159,7 +14169,7 @@ unicode = 0131;
 },
 {
 glyphname = iacute;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:27:10 +0000";
 layers = (
 {
 components = (
@@ -14168,7 +14178,7 @@ name = idotless;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 201, 0}";
+transform = "{1, 0, 0, 1, 189, -3}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -14181,7 +14191,7 @@ unicode = 00ED;
 },
 {
 glyphname = ibreve;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:27:10 +0000";
 layers = (
 {
 components = (
@@ -14190,7 +14200,7 @@ name = idotless;
 },
 {
 name = brevecomb;
-transform = "{1, 0, 0, 1, 201, 0}";
+transform = "{1, 0, 0, 1, 189, -3}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -14203,7 +14213,7 @@ unicode = 012D;
 },
 {
 glyphname = icaron;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:23:01 +0000";
 layers = (
 {
 components = (
@@ -14212,7 +14222,7 @@ name = idotless;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 201, 0}";
+transform = "{1, 0, 0, 1, 189, -3}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -14225,7 +14235,7 @@ unicode = 01D0;
 },
 {
 glyphname = icircumflex;
-lastChange = "2022-02-17 10:53:35 +0000";
+lastChange = "2022-02-28 12:27:10 +0000";
 layers = (
 {
 components = (
@@ -14234,7 +14244,7 @@ name = idotless;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 201, 0}";
+transform = "{1, 0, 0, 1, 189, -3}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -14247,7 +14257,7 @@ unicode = 00EE;
 },
 {
 glyphname = idblgrave;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:27:10 +0000";
 layers = (
 {
 components = (
@@ -14256,7 +14266,7 @@ name = idotless;
 },
 {
 name = dblgravecomb;
-transform = "{1, 0, 0, 1, 201, 0}";
+transform = "{1, 0, 0, 1, 189, -3}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -14269,7 +14279,7 @@ unicode = 0209;
 },
 {
 glyphname = idieresis;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:27:10 +0000";
 layers = (
 {
 components = (
@@ -14278,7 +14288,7 @@ name = idotless;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 201, 0}";
+transform = "{1, 0, 0, 1, 189, -3}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -14291,7 +14301,7 @@ unicode = 00EF;
 },
 {
 glyphname = idotaccent;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:27:10 +0000";
 layers = (
 {
 components = (
@@ -14300,7 +14310,7 @@ name = idotless;
 },
 {
 name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 201, 0}";
+transform = "{1, 0, 0, 1, 189, -3}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -14334,7 +14344,7 @@ unicode = 1ECB;
 },
 {
 glyphname = igrave;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:27:10 +0000";
 layers = (
 {
 components = (
@@ -14343,7 +14353,7 @@ name = idotless;
 },
 {
 name = gravecomb;
-transform = "{1, 0, 0, 1, 201, 0}";
+transform = "{1, 0, 0, 1, 189, -3}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -14356,7 +14366,7 @@ unicode = 00EC;
 },
 {
 glyphname = ihookabove;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:27:10 +0000";
 layers = (
 {
 components = (
@@ -14365,7 +14375,7 @@ name = idotless;
 },
 {
 name = hookabovecomb;
-transform = "{1, 0, 0, 1, 201, 0}";
+transform = "{1, 0, 0, 1, 189, -3}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -14378,7 +14388,7 @@ unicode = 1EC9;
 },
 {
 glyphname = iinvertedbreve;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:27:10 +0000";
 layers = (
 {
 components = (
@@ -14387,7 +14397,7 @@ name = idotless;
 },
 {
 name = breveinvertedcomb;
-transform = "{1, 0, 0, 1, 201, 0}";
+transform = "{1, 0, 0, 1, 189, -3}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -14400,7 +14410,7 @@ unicode = 020B;
 },
 {
 glyphname = imacron;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:27:10 +0000";
 layers = (
 {
 components = (
@@ -14409,7 +14419,7 @@ name = idotless;
 },
 {
 name = macroncomb;
-transform = "{1, 0, 0, 1, 201, 0}";
+transform = "{1, 0, 0, 1, 189, -3}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -14422,7 +14432,7 @@ unicode = 012B;
 },
 {
 glyphname = iogonek;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:27:10 +0000";
 layers = (
 {
 components = (
@@ -14431,7 +14441,7 @@ name = idotless;
 },
 {
 name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 201, 0}";
+transform = "{1, 0, 0, 1, 189, -3}";
 },
 {
 name = ogonekcomb;
@@ -14448,7 +14458,7 @@ unicode = 012F;
 },
 {
 glyphname = itilde;
-lastChange = "2022-02-17 11:35:53 +0000";
+lastChange = "2022-02-28 12:27:10 +0000";
 layers = (
 {
 components = (
@@ -14457,7 +14467,7 @@ name = idotless;
 },
 {
 name = tildecomb;
-transform = "{1, 0, 0, 1, 201, 0}";
+transform = "{1, 0, 0, 1, 189, -3}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -14470,7 +14480,7 @@ unicode = 0129;
 },
 {
 glyphname = j;
-lastChange = "2022-02-17 11:38:46 +0000";
+lastChange = "2022-02-28 14:56:42 +0000";
 layers = (
 {
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -14478,86 +14488,86 @@ paths = (
 {
 closed = 1;
 nodes = (
-"128 331 OFFCURVE",
-"131 348 OFFCURVE",
-"131 365 CURVE SMOOTH",
-"131 381 OFFCURVE",
-"128 397 OFFCURVE",
-"122 403 CURVE SMOOTH",
-"116 408 OFFCURVE",
-"108 411 OFFCURVE",
-"101 411 CURVE SMOOTH",
-"95 411 OFFCURVE",
-"88 408 OFFCURVE",
-"83 403 CURVE SMOOTH",
-"68 388 OFFCURVE",
-"61 371 OFFCURVE",
-"61 357 CURVE SMOOTH",
-"61 344 OFFCURVE",
-"67 333 OFFCURVE",
-"76 328 CURVE SMOOTH",
-"86 323 OFFCURVE",
-"97 318 OFFCURVE",
-"107 318 CURVE SMOOTH",
-"113 318 OFFCURVE",
-"118 320 OFFCURVE",
-"122 324 CURVE SMOOTH"
+"148 331 OFFCURVE",
+"151 348 OFFCURVE",
+"151 365 CURVE SMOOTH",
+"151 381 OFFCURVE",
+"148 397 OFFCURVE",
+"142 403 CURVE SMOOTH",
+"136 408 OFFCURVE",
+"128 411 OFFCURVE",
+"121 411 CURVE SMOOTH",
+"115 411 OFFCURVE",
+"108 408 OFFCURVE",
+"103 403 CURVE SMOOTH",
+"88 388 OFFCURVE",
+"81 371 OFFCURVE",
+"81 357 CURVE SMOOTH",
+"81 344 OFFCURVE",
+"87 333 OFFCURVE",
+"96 328 CURVE SMOOTH",
+"106 323 OFFCURVE",
+"117 318 OFFCURVE",
+"127 318 CURVE SMOOTH",
+"133 318 OFFCURVE",
+"138 320 OFFCURVE",
+"142 324 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"129 233 OFFCURVE",
-"116 252 OFFCURVE",
-"100 252 CURVE SMOOTH",
-"93 252 OFFCURVE",
-"85 248 OFFCURVE",
-"78 236 CURVE SMOOTH",
-"56 198 OFFCURVE",
-"51 176 OFFCURVE",
-"47 124 CURVE SMOOTH",
-"35 -11 OFFCURVE",
-"-31 -131 OFFCURVE",
-"-63 -171 CURVE SMOOTH",
-"-70 -181 OFFCURVE",
-"-112 -214 OFFCURVE",
-"-135 -214 CURVE SMOOTH",
-"-138 -214 OFFCURVE",
-"-141 -213 OFFCURVE",
-"-143 -212 CURVE SMOOTH",
-"-157 -202 OFFCURVE",
-"-165 -179 OFFCURVE",
-"-165 -161 CURVE SMOOTH",
-"-165 -157 OFFCURVE",
-"-164 -154 OFFCURVE",
-"-164 -151 CURVE SMOOTH",
-"-160 -125 OFFCURVE",
-"-151 -113 OFFCURVE",
-"-151 -103 CURVE",
-"-153 -99 OFFCURVE",
-"-156 -96 OFFCURVE",
-"-160 -96 CURVE SMOOTH",
-"-166 -96 OFFCURVE",
-"-173 -103 OFFCURVE",
-"-180 -124 CURVE SMOOTH",
-"-186 -144 OFFCURVE",
-"-196 -170 OFFCURVE",
-"-196 -194 CURVE SMOOTH",
-"-196 -211 OFFCURVE",
-"-191 -228 OFFCURVE",
-"-175 -240 CURVE SMOOTH",
-"-170 -244 OFFCURVE",
-"-163 -246 OFFCURVE",
-"-156 -246 CURVE SMOOTH",
-"-120 -246 OFFCURVE",
-"-62 -210 OFFCURVE",
-"-38 -196 CURVE",
-"36 -116 OFFCURVE",
-"61 -38 OFFCURVE",
-"95 123 CURVE SMOOTH",
-"103 160 OFFCURVE",
-"111 180 OFFCURVE",
-"124 222 CURVE"
+"149 233 OFFCURVE",
+"136 252 OFFCURVE",
+"120 252 CURVE SMOOTH",
+"113 252 OFFCURVE",
+"105 248 OFFCURVE",
+"98 236 CURVE SMOOTH",
+"76 198 OFFCURVE",
+"71 176 OFFCURVE",
+"67 124 CURVE SMOOTH",
+"55 -11 OFFCURVE",
+"-11 -131 OFFCURVE",
+"-43 -171 CURVE SMOOTH",
+"-50 -181 OFFCURVE",
+"-92 -214 OFFCURVE",
+"-115 -214 CURVE SMOOTH",
+"-118 -214 OFFCURVE",
+"-121 -213 OFFCURVE",
+"-123 -212 CURVE SMOOTH",
+"-137 -202 OFFCURVE",
+"-145 -179 OFFCURVE",
+"-145 -161 CURVE SMOOTH",
+"-145 -157 OFFCURVE",
+"-144 -154 OFFCURVE",
+"-144 -151 CURVE SMOOTH",
+"-140 -125 OFFCURVE",
+"-131 -113 OFFCURVE",
+"-131 -103 CURVE",
+"-133 -99 OFFCURVE",
+"-136 -96 OFFCURVE",
+"-140 -96 CURVE SMOOTH",
+"-146 -96 OFFCURVE",
+"-153 -103 OFFCURVE",
+"-160 -124 CURVE SMOOTH",
+"-166 -144 OFFCURVE",
+"-176 -170 OFFCURVE",
+"-176 -194 CURVE SMOOTH",
+"-176 -211 OFFCURVE",
+"-171 -228 OFFCURVE",
+"-155 -240 CURVE SMOOTH",
+"-150 -244 OFFCURVE",
+"-143 -246 OFFCURVE",
+"-136 -246 CURVE SMOOTH",
+"-100 -246 OFFCURVE",
+"-42 -210 OFFCURVE",
+"-18 -196 CURVE",
+"56 -116 OFFCURVE",
+"81 -38 OFFCURVE",
+"115 123 CURVE SMOOTH",
+"123 160 OFFCURVE",
+"131 180 OFFCURVE",
+"144 222 CURVE"
 );
 }
 );
@@ -14572,17 +14582,17 @@ unicode = 006A;
 {
 color = 1;
 glyphname = jdotless;
-lastChange = "2022-02-17 11:38:41 +0000";
+lastChange = "2022-02-28 14:56:44 +0000";
 layers = (
 {
 anchors = (
 {
 name = bottom;
-position = "{-126, -236}";
+position = "{-106, -236}";
 },
 {
 name = top;
-position = "{102, 232}";
+position = "{132, 226}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -14590,61 +14600,61 @@ paths = (
 {
 closed = 1;
 nodes = (
-"129 233 OFFCURVE",
-"116 252 OFFCURVE",
-"100 252 CURVE SMOOTH",
-"93 252 OFFCURVE",
-"85 248 OFFCURVE",
-"78 236 CURVE SMOOTH",
-"56 198 OFFCURVE",
-"51 176 OFFCURVE",
-"47 124 CURVE SMOOTH",
-"35 -11 OFFCURVE",
-"-31 -131 OFFCURVE",
-"-63 -171 CURVE SMOOTH",
-"-70 -181 OFFCURVE",
-"-112 -214 OFFCURVE",
-"-135 -214 CURVE SMOOTH",
-"-138 -214 OFFCURVE",
-"-141 -213 OFFCURVE",
-"-143 -212 CURVE SMOOTH",
-"-157 -202 OFFCURVE",
-"-165 -179 OFFCURVE",
-"-165 -161 CURVE SMOOTH",
-"-165 -157 OFFCURVE",
-"-164 -154 OFFCURVE",
-"-164 -151 CURVE SMOOTH",
-"-160 -125 OFFCURVE",
-"-151 -113 OFFCURVE",
-"-151 -103 CURVE",
-"-153 -99 OFFCURVE",
-"-156 -96 OFFCURVE",
-"-160 -96 CURVE SMOOTH",
-"-166 -96 OFFCURVE",
-"-173 -103 OFFCURVE",
-"-180 -124 CURVE SMOOTH",
-"-186 -144 OFFCURVE",
-"-196 -170 OFFCURVE",
-"-196 -194 CURVE SMOOTH",
-"-196 -211 OFFCURVE",
-"-191 -228 OFFCURVE",
-"-175 -240 CURVE SMOOTH",
-"-170 -244 OFFCURVE",
-"-163 -246 OFFCURVE",
-"-156 -246 CURVE SMOOTH",
-"-120 -246 OFFCURVE",
-"-62 -210 OFFCURVE",
-"-38 -196 CURVE",
-"36 -116 OFFCURVE",
-"61 -38 OFFCURVE",
-"95 123 CURVE SMOOTH",
-"103 160 OFFCURVE",
-"111 180 OFFCURVE",
-"124 222 CURVE"
+"149 233 OFFCURVE",
+"136 252 OFFCURVE",
+"120 252 CURVE SMOOTH",
+"113 252 OFFCURVE",
+"105 248 OFFCURVE",
+"98 236 CURVE SMOOTH",
+"76 198 OFFCURVE",
+"71 176 OFFCURVE",
+"67 124 CURVE SMOOTH",
+"55 -11 OFFCURVE",
+"-11 -131 OFFCURVE",
+"-43 -171 CURVE SMOOTH",
+"-50 -181 OFFCURVE",
+"-92 -214 OFFCURVE",
+"-115 -214 CURVE SMOOTH",
+"-118 -214 OFFCURVE",
+"-121 -213 OFFCURVE",
+"-123 -212 CURVE SMOOTH",
+"-137 -202 OFFCURVE",
+"-145 -179 OFFCURVE",
+"-145 -161 CURVE SMOOTH",
+"-145 -157 OFFCURVE",
+"-144 -154 OFFCURVE",
+"-144 -151 CURVE SMOOTH",
+"-140 -125 OFFCURVE",
+"-131 -113 OFFCURVE",
+"-131 -103 CURVE",
+"-133 -99 OFFCURVE",
+"-136 -96 OFFCURVE",
+"-140 -96 CURVE SMOOTH",
+"-146 -96 OFFCURVE",
+"-153 -103 OFFCURVE",
+"-160 -124 CURVE SMOOTH",
+"-166 -144 OFFCURVE",
+"-176 -170 OFFCURVE",
+"-176 -194 CURVE SMOOTH",
+"-176 -211 OFFCURVE",
+"-171 -228 OFFCURVE",
+"-155 -240 CURVE SMOOTH",
+"-150 -244 OFFCURVE",
+"-143 -246 OFFCURVE",
+"-136 -246 CURVE SMOOTH",
+"-100 -246 OFFCURVE",
+"-42 -210 OFFCURVE",
+"-18 -196 CURVE",
+"56 -116 OFFCURVE",
+"81 -38 OFFCURVE",
+"115 123 CURVE SMOOTH",
+"123 160 OFFCURVE",
+"131 180 OFFCURVE",
+"144 222 CURVE"
 );
 }
 );
-width = 135;
+width = 155;
 }
 );
 leftKerningGroup = j;
@@ -14653,7 +14663,7 @@ unicode = 0237;
 },
 {
 glyphname = jcircumflex;
-lastChange = "2022-02-17 11:38:41 +0000";
+lastChange = "2022-02-28 14:56:44 +0000";
 layers = (
 {
 components = (
@@ -14662,11 +14672,11 @@ name = jdotless;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 102, -68}";
+transform = "{1, 0, 0, 1, 132, -74}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 135;
+width = 155;
 }
 );
 leftKerningGroup = j;
@@ -15221,7 +15231,7 @@ unicode = 0140;
 },
 {
 glyphname = lj;
-lastChange = "2022-02-08 10:03:41 +0000";
+lastChange = "2022-02-28 14:57:15 +0000";
 layers = (
 {
 components = (
@@ -15512,7 +15522,7 @@ unicode = 006D;
 {
 color = 3;
 glyphname = n;
-lastChange = "2022-02-08 12:56:14 +0000";
+lastChange = "2022-02-28 12:27:09 +0000";
 layers = (
 {
 anchors = (
@@ -15522,7 +15532,7 @@ position = "{92, 0}";
 },
 {
 name = top;
-position = "{155, 255}";
+position = "{148, 245}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -15609,7 +15619,7 @@ unicode = 006E;
 },
 {
 glyphname = nacute;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:27:10 +0000";
 layers = (
 {
 components = (
@@ -15618,7 +15628,7 @@ name = n;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 155, -45}";
+transform = "{1, 0, 0, 1, 148, -55}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -15631,7 +15641,7 @@ unicode = 0144;
 },
 {
 glyphname = ncaron;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:27:09 +0000";
 layers = (
 {
 components = (
@@ -15640,7 +15650,7 @@ name = n;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 155, -45}";
+transform = "{1, 0, 0, 1, 148, -55}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -15672,50 +15682,6 @@ width = 264;
 leftKerningGroup = n;
 rightKerningGroup = n;
 unicode = 0146;
-},
-{
-glyphname = nj;
-lastChange = "2022-02-08 10:04:01 +0000";
-layers = (
-{
-components = (
-{
-name = n;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 264, 0}";
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 419;
-}
-);
-leftKerningGroup = n;
-rightKerningGroup = j;
-unicode = 01CC;
-},
-{
-glyphname = ntilde;
-lastChange = "2022-02-17 10:26:19 +0000";
-layers = (
-{
-components = (
-{
-name = n;
-},
-{
-name = tildecomb;
-transform = "{1, 0, 0, 1, 155, -45}";
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 264;
-}
-);
-leftKerningGroup = n;
-rightKerningGroup = n;
-unicode = 00F1;
 },
 {
 color = 3;
@@ -15829,9 +15795,55 @@ rightKerningGroup = n;
 unicode = 014B;
 },
 {
+glyphname = nj;
+lastChange = "2022-02-28 14:57:24 +0000";
+layers = (
+{
+components = (
+{
+name = n;
+},
+{
+alignment = -1;
+name = j;
+transform = "{1, 0, 0, 1, 204, 0}";
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 359;
+}
+);
+leftKerningGroup = n;
+rightKerningGroup = j;
+rightMetricsKey = j;
+unicode = 01CC;
+},
+{
+glyphname = ntilde;
+lastChange = "2022-02-28 12:27:10 +0000";
+layers = (
+{
+components = (
+{
+name = n;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 148, -55}";
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 264;
+}
+);
+leftKerningGroup = n;
+rightKerningGroup = n;
+unicode = 00F1;
+},
+{
 color = 3;
 glyphname = o;
-lastChange = "2022-02-08 10:04:14 +0000";
+lastChange = "2022-02-28 12:29:03 +0000";
 layers = (
 {
 anchors = (
@@ -15849,7 +15861,7 @@ position = "{108, 0}";
 },
 {
 name = top;
-position = "{160, 255}";
+position = "{162, 247}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -15977,7 +15989,7 @@ unicode = 006F;
 },
 {
 glyphname = oacute;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:29:05 +0000";
 layers = (
 {
 components = (
@@ -15986,7 +15998,7 @@ name = o;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -15999,7 +16011,7 @@ unicode = 00F3;
 },
 {
 glyphname = obreve;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:29:05 +0000";
 layers = (
 {
 components = (
@@ -16008,7 +16020,7 @@ name = o;
 },
 {
 name = brevecomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -16022,7 +16034,7 @@ unicode = 014F;
 {
 color = 9;
 glyphname = ocaron;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:29:03 +0000";
 layers = (
 {
 components = (
@@ -16031,7 +16043,7 @@ name = o;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -16044,7 +16056,7 @@ unicode = 01D2;
 },
 {
 glyphname = ocircumflex;
-lastChange = "2022-02-17 10:53:35 +0000";
+lastChange = "2022-02-28 12:29:05 +0000";
 layers = (
 {
 components = (
@@ -16053,7 +16065,7 @@ name = o;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -16066,7 +16078,7 @@ unicode = 00F4;
 },
 {
 glyphname = ocircumflexacute;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:29:05 +0000";
 layers = (
 {
 components = (
@@ -16075,7 +16087,7 @@ name = o;
 },
 {
 name = circumflexcomb_acutecomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -16088,7 +16100,7 @@ unicode = 1ED1;
 },
 {
 glyphname = ocircumflexdotbelow;
-lastChange = "2022-02-17 10:53:35 +0000";
+lastChange = "2022-02-28 12:29:05 +0000";
 layers = (
 {
 components = (
@@ -16101,7 +16113,7 @@ transform = "{1, 0, 0, 1, 69, 0}";
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -16114,7 +16126,7 @@ unicode = 1ED9;
 },
 {
 glyphname = ocircumflexgrave;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:29:05 +0000";
 layers = (
 {
 components = (
@@ -16123,7 +16135,7 @@ name = o;
 },
 {
 name = circumflexcomb_gravecomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -16136,7 +16148,7 @@ unicode = 1ED3;
 },
 {
 glyphname = ocircumflexhookabove;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:29:05 +0000";
 layers = (
 {
 components = (
@@ -16145,7 +16157,7 @@ name = o;
 },
 {
 name = circumflexcomb_hookabovecomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -16158,7 +16170,7 @@ unicode = 1ED5;
 },
 {
 glyphname = ocircumflextilde;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:29:05 +0000";
 layers = (
 {
 components = (
@@ -16167,7 +16179,7 @@ name = o;
 },
 {
 name = circumflexcomb_tildecomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -16180,7 +16192,7 @@ unicode = 1ED7;
 },
 {
 glyphname = odblgrave;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:29:05 +0000";
 layers = (
 {
 components = (
@@ -16189,7 +16201,7 @@ name = o;
 },
 {
 name = dblgravecomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -16202,7 +16214,7 @@ unicode = 020D;
 },
 {
 glyphname = odieresis;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:29:05 +0000";
 layers = (
 {
 components = (
@@ -16211,7 +16223,7 @@ name = o;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -16224,7 +16236,7 @@ unicode = 00F6;
 },
 {
 glyphname = odieresismacron;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 14:18:27 +0000";
 layers = (
 {
 components = (
@@ -16233,11 +16245,12 @@ name = o;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 },
 {
+alignment = -1;
 name = macroncomb;
-transform = "{1, 0, 0, 1, 160, 75}";
+transform = "{1, 0, 0, 1, 172, 37}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -16250,7 +16263,7 @@ unicode = 022B;
 },
 {
 glyphname = odotaccentmacron;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 14:18:33 +0000";
 layers = (
 {
 components = (
@@ -16259,11 +16272,12 @@ name = o;
 },
 {
 name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 },
 {
+alignment = -1;
 name = macroncomb;
-transform = "{1, 0, 0, 1, 160, 75}";
+transform = "{1, 0, 0, 1, 172, 37}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -16298,7 +16312,7 @@ unicode = 1ECD;
 },
 {
 glyphname = ograve;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 14:19:38 +0000";
 layers = (
 {
 components = (
@@ -16307,7 +16321,7 @@ name = o;
 },
 {
 name = gravecomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -16320,7 +16334,7 @@ unicode = 00F2;
 },
 {
 glyphname = ohookabove;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:29:05 +0000";
 layers = (
 {
 components = (
@@ -16329,7 +16343,7 @@ name = o;
 },
 {
 name = hookabovecomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -16342,7 +16356,7 @@ unicode = 1ECF;
 },
 {
 glyphname = ohorn;
-lastChange = "2022-02-08 10:04:14 +0000";
+lastChange = "2022-02-28 14:23:20 +0000";
 layers = (
 {
 components = (
@@ -16355,16 +16369,17 @@ transform = "{1, 0, 0, 1, 202, -10}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 242;
+width = 262;
 }
 );
 leftKerningGroup = o;
 rightKerningGroup = o;
+rightMetricsKey = "=+20";
 unicode = 01A1;
 },
 {
 glyphname = ohornacute;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 14:23:21 +0000";
 layers = (
 {
 components = (
@@ -16373,11 +16388,11 @@ name = ohorn;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 242;
+width = 262;
 }
 );
 leftKerningGroup = o;
@@ -16386,7 +16401,7 @@ unicode = 1EDB;
 },
 {
 glyphname = ohorndotbelow;
-lastChange = "2022-02-08 10:04:14 +0000";
+lastChange = "2022-02-28 14:23:23 +0000";
 layers = (
 {
 components = (
@@ -16399,7 +16414,7 @@ transform = "{1, 0, 0, 1, 69, 0}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 242;
+width = 262;
 }
 );
 leftKerningGroup = o;
@@ -16408,7 +16423,7 @@ unicode = 1EE3;
 },
 {
 glyphname = ohorngrave;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 14:23:24 +0000";
 layers = (
 {
 components = (
@@ -16417,11 +16432,11 @@ name = ohorn;
 },
 {
 name = gravecomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 242;
+width = 262;
 }
 );
 leftKerningGroup = o;
@@ -16430,7 +16445,7 @@ unicode = 1EDD;
 },
 {
 glyphname = ohornhookabove;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 14:23:25 +0000";
 layers = (
 {
 components = (
@@ -16439,11 +16454,11 @@ name = ohorn;
 },
 {
 name = hookabovecomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 242;
+width = 262;
 }
 );
 leftKerningGroup = o;
@@ -16452,7 +16467,7 @@ unicode = 1EDF;
 },
 {
 glyphname = ohorntilde;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 14:23:27 +0000";
 layers = (
 {
 components = (
@@ -16461,11 +16476,11 @@ name = ohorn;
 },
 {
 name = tildecomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 242;
+width = 262;
 }
 );
 leftKerningGroup = o;
@@ -16474,7 +16489,7 @@ unicode = 1EE1;
 },
 {
 glyphname = ohungarumlaut;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:29:05 +0000";
 layers = (
 {
 components = (
@@ -16483,7 +16498,7 @@ name = o;
 },
 {
 name = hungarumlautcomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -16496,7 +16511,7 @@ unicode = 0151;
 },
 {
 glyphname = oinvertedbreve;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:29:05 +0000";
 layers = (
 {
 components = (
@@ -16505,7 +16520,7 @@ name = o;
 },
 {
 name = breveinvertedcomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -16518,7 +16533,7 @@ unicode = 020F;
 },
 {
 glyphname = omacron;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:29:05 +0000";
 layers = (
 {
 components = (
@@ -16527,7 +16542,7 @@ name = o;
 },
 {
 name = macroncomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -16563,13 +16578,13 @@ unicode = 01EB;
 {
 color = 3;
 glyphname = oslash;
-lastChange = "2022-02-08 10:04:14 +0000";
+lastChange = "2022-02-28 14:03:32 +0000";
 layers = (
 {
 anchors = (
 {
 name = top;
-position = "{160, 255}";
+position = "{140, 255}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -16624,7 +16639,7 @@ nodes = (
 "254 65 OFFCURVE",
 "254 130 CURVE SMOOTH",
 "254 185 OFFCURVE",
-"209 210 OFFCURVE",
+"209 209 OFFCURVE",
 "159 209 CURVE SMOOTH",
 "158 209 LINE",
 "164 221 OFFCURVE",
@@ -16695,7 +16710,7 @@ unicode = 00F8;
 },
 {
 glyphname = oslashacute;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 14:03:32 +0000";
 layers = (
 {
 components = (
@@ -16704,7 +16719,7 @@ name = oslash;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 140, -45}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -16717,7 +16732,7 @@ unicode = 01FF;
 },
 {
 glyphname = otilde;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:29:05 +0000";
 layers = (
 {
 components = (
@@ -16726,7 +16741,7 @@ name = o;
 },
 {
 name = tildecomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -16739,7 +16754,7 @@ unicode = 00F5;
 },
 {
 glyphname = otildemacron;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:29:05 +0000";
 layers = (
 {
 components = (
@@ -16748,7 +16763,7 @@ name = o;
 },
 {
 name = tildecomb_macroncomb;
-transform = "{1, 0, 0, 1, 160, -45}";
+transform = "{1, 0, 0, 1, 162, -53}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -17443,7 +17458,7 @@ unicode = 0071;
 {
 color = 3;
 glyphname = r;
-lastChange = "2022-02-08 14:29:16 +0000";
+lastChange = "2022-02-28 12:29:33 +0000";
 layers = (
 {
 anchors = (
@@ -17453,7 +17468,7 @@ position = "{38, 0}";
 },
 {
 name = top;
-position = "{166, 255}";
+position = "{157, 241}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -17575,7 +17590,7 @@ unicode = 0072;
 },
 {
 glyphname = racute;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:29:39 +0000";
 layers = (
 {
 components = (
@@ -17584,7 +17599,7 @@ name = r;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 166, -45}";
+transform = "{1, 0, 0, 1, 157, -59}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -17597,7 +17612,7 @@ unicode = 0155;
 },
 {
 glyphname = rcaron;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:29:33 +0000";
 layers = (
 {
 components = (
@@ -17606,7 +17621,7 @@ name = r;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 166, -45}";
+transform = "{1, 0, 0, 1, 157, -59}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -17641,7 +17656,7 @@ unicode = 0157;
 },
 {
 glyphname = rdblgrave;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:29:39 +0000";
 layers = (
 {
 components = (
@@ -17650,7 +17665,7 @@ name = r;
 },
 {
 name = dblgravecomb;
-transform = "{1, 0, 0, 1, 166, -45}";
+transform = "{1, 0, 0, 1, 157, -59}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -17663,7 +17678,7 @@ unicode = 0211;
 },
 {
 glyphname = rinvertedbreve;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:29:39 +0000";
 layers = (
 {
 components = (
@@ -17672,7 +17687,7 @@ name = r;
 },
 {
 name = breveinvertedcomb;
-transform = "{1, 0, 0, 1, 166, -45}";
+transform = "{1, 0, 0, 1, 157, -59}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -17686,7 +17701,7 @@ unicode = 0213;
 {
 color = 3;
 glyphname = s;
-lastChange = "2022-02-10 16:14:41 +0000";
+lastChange = "2022-02-28 12:30:01 +0000";
 layers = (
 {
 anchors = (
@@ -17700,7 +17715,7 @@ position = "{107, 0}";
 },
 {
 name = top;
-position = "{150, 255}";
+position = "{151, 267}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -17856,7 +17871,7 @@ unicode = 0073;
 },
 {
 glyphname = sacute;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:30:05 +0000";
 layers = (
 {
 components = (
@@ -17865,7 +17880,7 @@ name = s;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 150, -45}";
+transform = "{1, 0, 0, 1, 151, -33}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -17878,7 +17893,7 @@ unicode = 015B;
 },
 {
 glyphname = scaron;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:30:01 +0000";
 layers = (
 {
 components = (
@@ -17887,7 +17902,7 @@ name = s;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 150, -45}";
+transform = "{1, 0, 0, 1, 151, -33}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -17922,7 +17937,7 @@ unicode = 015F;
 },
 {
 glyphname = scircumflex;
-lastChange = "2022-02-17 10:53:35 +0000";
+lastChange = "2022-02-28 12:30:05 +0000";
 layers = (
 {
 components = (
@@ -17931,7 +17946,7 @@ name = s;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 150, -45}";
+transform = "{1, 0, 0, 1, 151, -33}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -18126,7 +18141,7 @@ unicode = 00DF;
 {
 color = 3;
 glyphname = t;
-lastChange = "2022-02-17 10:45:38 +0000";
+lastChange = "2022-02-28 14:19:16 +0000";
 layers = (
 {
 anchors = (
@@ -18397,7 +18412,7 @@ unicode = 021B;
 {
 color = 3;
 glyphname = u;
-lastChange = "2022-02-08 14:32:03 +0000";
+lastChange = "2022-02-28 12:30:37 +0000";
 layers = (
 {
 anchors = (
@@ -18415,7 +18430,7 @@ position = "{262, 30}";
 },
 {
 name = top;
-position = "{181, 340}";
+position = "{173, 316}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -18502,7 +18517,7 @@ unicode = 0075;
 },
 {
 glyphname = uacute;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:30:39 +0000";
 layers = (
 {
 components = (
@@ -18511,7 +18526,7 @@ name = u;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 181, 40}";
+transform = "{1, 0, 0, 1, 173, 16}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -18524,7 +18539,7 @@ unicode = 00FA;
 },
 {
 glyphname = ubreve;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:30:39 +0000";
 layers = (
 {
 components = (
@@ -18533,7 +18548,7 @@ name = u;
 },
 {
 name = brevecomb;
-transform = "{1, 0, 0, 1, 181, 40}";
+transform = "{1, 0, 0, 1, 173, 16}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -18547,7 +18562,7 @@ unicode = 016D;
 {
 color = 9;
 glyphname = ucaron;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:30:37 +0000";
 layers = (
 {
 components = (
@@ -18556,7 +18571,7 @@ name = u;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 181, 40}";
+transform = "{1, 0, 0, 1, 173, 16}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -18569,7 +18584,7 @@ unicode = 01D4;
 },
 {
 glyphname = ucircumflex;
-lastChange = "2022-02-17 10:53:35 +0000";
+lastChange = "2022-02-28 12:30:39 +0000";
 layers = (
 {
 components = (
@@ -18578,7 +18593,7 @@ name = u;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 181, 40}";
+transform = "{1, 0, 0, 1, 173, 16}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -18591,7 +18606,7 @@ unicode = 00FB;
 },
 {
 glyphname = udblgrave;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:30:39 +0000";
 layers = (
 {
 components = (
@@ -18600,7 +18615,7 @@ name = u;
 },
 {
 name = dblgravecomb;
-transform = "{1, 0, 0, 1, 181, 40}";
+transform = "{1, 0, 0, 1, 173, 16}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -18613,7 +18628,7 @@ unicode = 0215;
 },
 {
 glyphname = udieresis;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:30:39 +0000";
 layers = (
 {
 components = (
@@ -18622,7 +18637,7 @@ name = u;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 181, 40}";
+transform = "{1, 0, 0, 1, 173, 16}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -18636,7 +18651,7 @@ unicode = 00FC;
 {
 color = 9;
 glyphname = udieresiscaron;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 13:43:49 +0000";
 layers = (
 {
 components = (
@@ -18645,12 +18660,12 @@ name = u;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 181, 40}";
+transform = "{1, 0, 0, 1, 173, 16}";
 },
 {
 alignment = -1;
 name = caroncomb;
-transform = "{1, 0, 0, 1, 181, 175}";
+transform = "{1, 0, 0, 1, 183, 126}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -18664,7 +18679,7 @@ unicode = 01DA;
 {
 color = 9;
 glyphname = udieresisgrave;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 13:43:56 +0000";
 layers = (
 {
 components = (
@@ -18673,12 +18688,12 @@ name = u;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 181, 40}";
+transform = "{1, 0, 0, 1, 173, 16}";
 },
 {
 alignment = -1;
 name = gravecomb;
-transform = "{1, 0, 0, 1, 181, 175}";
+transform = "{1, 0, 0, 1, 183, 126}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -18692,7 +18707,7 @@ unicode = 01DC;
 {
 color = 9;
 glyphname = udieresismacron;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 13:44:07 +0000";
 layers = (
 {
 components = (
@@ -18701,12 +18716,12 @@ name = u;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 181, 40}";
+transform = "{1, 0, 0, 1, 173, 16}";
 },
 {
 alignment = -1;
 name = macroncomb;
-transform = "{1, 0, 0, 1, 181, 175}";
+transform = "{1, 0, 0, 1, 189, 116}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -18741,7 +18756,7 @@ unicode = 1EE5;
 },
 {
 glyphname = ugrave;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:30:39 +0000";
 layers = (
 {
 components = (
@@ -18750,7 +18765,7 @@ name = u;
 },
 {
 name = gravecomb;
-transform = "{1, 0, 0, 1, 181, 40}";
+transform = "{1, 0, 0, 1, 173, 16}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -18763,7 +18778,7 @@ unicode = 00F9;
 },
 {
 glyphname = uhookabove;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:30:39 +0000";
 layers = (
 {
 components = (
@@ -18772,7 +18787,7 @@ name = u;
 },
 {
 name = hookabovecomb;
-transform = "{1, 0, 0, 1, 181, 40}";
+transform = "{1, 0, 0, 1, 173, 16}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -18785,7 +18800,7 @@ unicode = 1EE7;
 },
 {
 glyphname = uhorn;
-lastChange = "2022-02-08 10:05:20 +0000";
+lastChange = "2022-02-28 14:26:35 +0000";
 layers = (
 {
 components = (
@@ -18807,7 +18822,7 @@ unicode = 01B0;
 },
 {
 glyphname = uhornacute;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 14:26:41 +0000";
 layers = (
 {
 components = (
@@ -18816,7 +18831,7 @@ name = uhorn;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 181, 40}";
+transform = "{1, 0, 0, 1, 173, 16}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -18829,7 +18844,7 @@ unicode = 1EE9;
 },
 {
 glyphname = uhorndotbelow;
-lastChange = "2022-02-08 10:05:20 +0000";
+lastChange = "2022-02-28 14:26:45 +0000";
 layers = (
 {
 components = (
@@ -18851,7 +18866,7 @@ unicode = 1EF1;
 },
 {
 glyphname = uhorngrave;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 14:26:52 +0000";
 layers = (
 {
 components = (
@@ -18860,7 +18875,7 @@ name = uhorn;
 },
 {
 name = gravecomb;
-transform = "{1, 0, 0, 1, 181, 40}";
+transform = "{1, 0, 0, 1, 173, 16}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -18873,7 +18888,7 @@ unicode = 1EEB;
 },
 {
 glyphname = uhornhookabove;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 14:26:56 +0000";
 layers = (
 {
 components = (
@@ -18882,7 +18897,7 @@ name = uhorn;
 },
 {
 name = hookabovecomb;
-transform = "{1, 0, 0, 1, 181, 40}";
+transform = "{1, 0, 0, 1, 173, 16}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -18895,7 +18910,7 @@ unicode = 1EED;
 },
 {
 glyphname = uhorntilde;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 14:26:59 +0000";
 layers = (
 {
 components = (
@@ -18904,7 +18919,7 @@ name = uhorn;
 },
 {
 name = tildecomb;
-transform = "{1, 0, 0, 1, 181, 40}";
+transform = "{1, 0, 0, 1, 173, 16}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -18917,7 +18932,7 @@ unicode = 1EEF;
 },
 {
 glyphname = uhungarumlaut;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:30:39 +0000";
 layers = (
 {
 components = (
@@ -18926,7 +18941,7 @@ name = u;
 },
 {
 name = hungarumlautcomb;
-transform = "{1, 0, 0, 1, 181, 40}";
+transform = "{1, 0, 0, 1, 173, 16}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -18939,7 +18954,7 @@ unicode = 0171;
 },
 {
 glyphname = uinvertedbreve;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:30:39 +0000";
 layers = (
 {
 components = (
@@ -18948,7 +18963,7 @@ name = u;
 },
 {
 name = breveinvertedcomb;
-transform = "{1, 0, 0, 1, 181, 40}";
+transform = "{1, 0, 0, 1, 173, 16}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -18961,7 +18976,7 @@ unicode = 0217;
 },
 {
 glyphname = umacron;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:30:39 +0000";
 layers = (
 {
 components = (
@@ -18970,7 +18985,7 @@ name = u;
 },
 {
 name = macroncomb;
-transform = "{1, 0, 0, 1, 181, 40}";
+transform = "{1, 0, 0, 1, 173, 16}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -19005,7 +19020,7 @@ unicode = 0173;
 },
 {
 glyphname = uring;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:30:39 +0000";
 layers = (
 {
 components = (
@@ -19014,7 +19029,7 @@ name = u;
 },
 {
 name = ringcomb;
-transform = "{1, 0, 0, 1, 181, 40}";
+transform = "{1, 0, 0, 1, 173, 16}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -19027,7 +19042,7 @@ unicode = 016F;
 },
 {
 glyphname = utilde;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:30:39 +0000";
 layers = (
 {
 components = (
@@ -19036,7 +19051,7 @@ name = u;
 },
 {
 name = tildecomb;
-transform = "{1, 0, 0, 1, 181, 40}";
+transform = "{1, 0, 0, 1, 173, 16}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -19160,7 +19175,7 @@ unicode = 0076;
 {
 color = 3;
 glyphname = w;
-lastChange = "2022-02-08 10:05:26 +0000";
+lastChange = "2022-02-28 14:06:29 +0000";
 layers = (
 {
 anchors = (
@@ -19170,7 +19185,7 @@ position = "{77, 0}";
 },
 {
 name = top;
-position = "{263, 255}";
+position = "{253, 235}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -19319,7 +19334,7 @@ unicode = 0077;
 },
 {
 glyphname = wacute;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 14:06:35 +0000";
 layers = (
 {
 components = (
@@ -19328,7 +19343,7 @@ name = w;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 263, -45}";
+transform = "{1, 0, 0, 1, 253, -65}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -19341,7 +19356,7 @@ unicode = 1E83;
 },
 {
 glyphname = wcircumflex;
-lastChange = "2022-02-17 10:53:35 +0000";
+lastChange = "2022-02-28 14:06:29 +0000";
 layers = (
 {
 components = (
@@ -19350,7 +19365,7 @@ name = w;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 263, -45}";
+transform = "{1, 0, 0, 1, 253, -65}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -19363,7 +19378,7 @@ unicode = 0175;
 },
 {
 glyphname = wdieresis;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 14:06:33 +0000";
 layers = (
 {
 components = (
@@ -19372,7 +19387,7 @@ name = w;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 263, -45}";
+transform = "{1, 0, 0, 1, 253, -65}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -19385,7 +19400,7 @@ unicode = 1E85;
 },
 {
 glyphname = wgrave;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 14:06:33 +0000";
 layers = (
 {
 components = (
@@ -19394,7 +19409,7 @@ name = w;
 },
 {
 name = gravecomb;
-transform = "{1, 0, 0, 1, 263, -45}";
+transform = "{1, 0, 0, 1, 253, -65}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -19549,17 +19564,17 @@ unicode = 0078;
 {
 color = 3;
 glyphname = y;
-lastChange = "2022-02-08 10:05:40 +0000";
+lastChange = "2022-02-28 12:31:09 +0000";
 layers = (
 {
 anchors = (
 {
 name = bottom;
-position = "{196, -100}";
+position = "{226, -100}";
 },
 {
 name = top;
-position = "{205, 277}";
+position = "{187, 270}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -19721,7 +19736,7 @@ unicode = 0079;
 },
 {
 glyphname = yacute;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:31:09 +0000";
 layers = (
 {
 components = (
@@ -19730,7 +19745,7 @@ name = y;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 205, -23}";
+transform = "{1, 0, 0, 1, 187, -30}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -19743,7 +19758,7 @@ unicode = 00FD;
 },
 {
 glyphname = ycircumflex;
-lastChange = "2022-02-17 10:53:35 +0000";
+lastChange = "2022-02-28 12:31:09 +0000";
 layers = (
 {
 components = (
@@ -19752,7 +19767,7 @@ name = y;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 205, -23}";
+transform = "{1, 0, 0, 1, 187, -30}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -19765,7 +19780,7 @@ unicode = 0177;
 },
 {
 glyphname = ydieresis;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:31:09 +0000";
 layers = (
 {
 components = (
@@ -19774,7 +19789,7 @@ name = y;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 205, -23}";
+transform = "{1, 0, 0, 1, 187, -30}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -19787,7 +19802,7 @@ unicode = 00FF;
 },
 {
 glyphname = ydotbelow;
-lastChange = "2022-02-08 10:05:40 +0000";
+lastChange = "2022-02-28 12:31:09 +0000";
 layers = (
 {
 components = (
@@ -19796,7 +19811,7 @@ name = y;
 },
 {
 name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 196, -100}";
+transform = "{1, 0, 0, 1, 226, -100}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -19809,7 +19824,7 @@ unicode = 1EF5;
 },
 {
 glyphname = ygrave;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:31:09 +0000";
 layers = (
 {
 components = (
@@ -19818,7 +19833,7 @@ name = y;
 },
 {
 name = gravecomb;
-transform = "{1, 0, 0, 1, 205, -23}";
+transform = "{1, 0, 0, 1, 187, -30}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -19831,7 +19846,7 @@ unicode = 1EF3;
 },
 {
 glyphname = yhookabove;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:31:09 +0000";
 layers = (
 {
 components = (
@@ -19840,7 +19855,7 @@ name = y;
 },
 {
 name = hookabovecomb;
-transform = "{1, 0, 0, 1, 205, -23}";
+transform = "{1, 0, 0, 1, 187, -30}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -19853,7 +19868,7 @@ unicode = 1EF7;
 },
 {
 glyphname = ymacron;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:31:09 +0000";
 layers = (
 {
 components = (
@@ -19862,7 +19877,7 @@ name = y;
 },
 {
 name = macroncomb;
-transform = "{1, 0, 0, 1, 205, -23}";
+transform = "{1, 0, 0, 1, 187, -30}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -19875,7 +19890,7 @@ unicode = 0233;
 },
 {
 glyphname = ytilde;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:31:09 +0000";
 layers = (
 {
 components = (
@@ -19884,7 +19899,7 @@ name = y;
 },
 {
 name = tildecomb;
-transform = "{1, 0, 0, 1, 205, -23}";
+transform = "{1, 0, 0, 1, 187, -30}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -19898,7 +19913,7 @@ unicode = 1EF9;
 {
 color = 3;
 glyphname = z;
-lastChange = "2022-02-08 10:05:45 +0000";
+lastChange = "2022-02-28 12:52:37 +0000";
 layers = (
 {
 anchors = (
@@ -19908,7 +19923,7 @@ position = "{152, 0}";
 },
 {
 name = top;
-position = "{242, 280}";
+position = "{222, 268}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -20052,7 +20067,7 @@ unicode = 007A;
 },
 {
 glyphname = zacute;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 13:05:54 +0000";
 layers = (
 {
 components = (
@@ -20061,7 +20076,7 @@ name = z;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 242, -20}";
+transform = "{1, 0, 0, 1, 222, -32}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -20074,7 +20089,7 @@ unicode = 017A;
 },
 {
 glyphname = zcaron;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 12:52:37 +0000";
 layers = (
 {
 components = (
@@ -20083,7 +20098,7 @@ name = z;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 242, -20}";
+transform = "{1, 0, 0, 1, 222, -32}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -20096,7 +20111,7 @@ unicode = 017E;
 },
 {
 glyphname = zdotaccent;
-lastChange = "2022-02-17 10:26:19 +0000";
+lastChange = "2022-02-28 13:05:54 +0000";
 layers = (
 {
 components = (
@@ -20105,7 +20120,7 @@ name = z;
 },
 {
 name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 242, -20}";
+transform = "{1, 0, 0, 1, 222, -32}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -20115,6 +20130,375 @@ width = 403;
 leftKerningGroup = z;
 rightKerningGroup = z;
 unicode = 017C;
+},
+{
+glyphname = dcroat.alt;
+lastChange = "2022-02-28 15:00:16 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"447 561 OFFCURVE",
+"448 573 OFFCURVE",
+"448 584 CURVE SMOOTH",
+"448 606 OFFCURVE",
+"442 626 OFFCURVE",
+"417 626 CURVE SMOOTH",
+"400 626 OFFCURVE",
+"388 614 OFFCURVE",
+"376 598 CURVE SMOOTH",
+"343 557 OFFCURVE",
+"315 509 OFFCURVE",
+"296 464 CURVE SMOOTH",
+"266 395 OFFCURVE",
+"250 365 OFFCURVE",
+"221 258 CURVE",
+"206 262 OFFCURVE",
+"189 264 OFFCURVE",
+"173 264 CURVE SMOOTH",
+"96 264 OFFCURVE",
+"14 220 OFFCURVE",
+"14 113 CURVE SMOOTH",
+"14 76 OFFCURVE",
+"54 38 OFFCURVE",
+"101 38 CURVE SMOOTH",
+"143 38 OFFCURVE",
+"168 71 OFFCURVE",
+"218 93 CURVE",
+"227 71 OFFCURVE",
+"240 9 OFFCURVE",
+"294 9 CURVE SMOOTH",
+"316 9 OFFCURVE",
+"338 29 OFFCURVE",
+"360 48 CURVE SMOOTH",
+"366 53 OFFCURVE",
+"375 68 OFFCURVE",
+"375 74 CURVE SMOOTH",
+"375 76 OFFCURVE",
+"374 77 OFFCURVE",
+"372 77 CURVE SMOOTH",
+"368 77 OFFCURVE",
+"361 72 OFFCURVE",
+"347 60 CURVE SMOOTH",
+"334 49 OFFCURVE",
+"306 33 OFFCURVE",
+"288 33 CURVE SMOOTH",
+"258 33 OFFCURVE",
+"247 112 OFFCURVE",
+"247 112 CURVE",
+"247 143 OFFCURVE",
+"409 338 OFFCURVE",
+"445 551 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"420 529 OFFCURVE",
+"393 442 OFFCURVE",
+"373 395 CURVE SMOOTH",
+"328 292 OFFCURVE",
+"258 188 OFFCURVE",
+"249 175 CURVE",
+"253 191 OFFCURVE",
+"255 207 OFFCURVE",
+"255 220 CURVE SMOOTH",
+"255 233 OFFCURVE",
+"253 243 OFFCURVE",
+"248 248 CURVE",
+"257 267 OFFCURVE",
+"296 355 OFFCURVE",
+"333 431 CURVE SMOOTH",
+"365 496 OFFCURVE",
+"403 553 OFFCURVE",
+"421 567 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"203 172 OFFCURVE",
+"206 155 OFFCURVE",
+"201 142 CURVE SMOOTH",
+"184 97 OFFCURVE",
+"130 61 OFFCURVE",
+"102 61 CURVE SMOOTH",
+"99 61 OFFCURVE",
+"96 61 OFFCURVE",
+"94 62 CURVE SMOOTH",
+"78 68 OFFCURVE",
+"72 83 OFFCURVE",
+"72 101 CURVE SMOOTH",
+"72 123 OFFCURVE",
+"81 148 OFFCURVE",
+"87 156 CURVE SMOOTH",
+"113 194 OFFCURVE",
+"147 231 OFFCURVE",
+"184 231 CURVE SMOOTH",
+"190 231 OFFCURVE",
+"195 230 OFFCURVE",
+"201 228 CURVE SMOOTH",
+"206 227 OFFCURVE",
+"208 222 OFFCURVE",
+"208 215 CURVE SMOOTH",
+"208 208 OFFCURVE",
+"206 198 OFFCURVE",
+"205 188 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"402 318 OFFCURVE",
+"383 321 OFFCURVE",
+"351 321 CURVE SMOOTH",
+"232 321 LINE SMOOTH",
+"209 321 OFFCURVE",
+"176 316 OFFCURVE",
+"160 316 CURVE SMOOTH",
+"150 316 OFFCURVE",
+"146 313 OFFCURVE",
+"146 309 CURVE SMOOTH",
+"146 304 OFFCURVE",
+"152 298 OFFCURVE",
+"162 294 CURVE SMOOTH",
+"169 292 OFFCURVE",
+"179 291 OFFCURVE",
+"189 291 CURVE SMOOTH",
+"200 291 OFFCURVE",
+"214 292 OFFCURVE",
+"226 292 CURVE SMOOTH",
+"232 292 OFFCURVE",
+"237 292 OFFCURVE",
+"242 291 CURVE",
+"273 289 OFFCURVE",
+"365 288 OFFCURVE",
+"398 288 CURVE SMOOTH",
+"411 288 OFFCURVE",
+"422 296 OFFCURVE",
+"422 304 CURVE SMOOTH",
+"422 308 OFFCURVE",
+"418 312 OFFCURVE",
+"411 314 CURVE"
+);
+}
+);
+width = 351;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = d;
+},
+{
+color = 3;
+glyphname = i.alt;
+lastChange = "2022-02-28 15:12:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{13, 10}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"241 495 OFFCURVE",
+"234 497 OFFCURVE",
+"228 497 CURVE SMOOTH",
+"221 497 OFFCURVE",
+"215 495 OFFCURVE",
+"209 489 CURVE SMOOTH",
+"194 474 OFFCURVE",
+"188 457 OFFCURVE",
+"188 443 CURVE SMOOTH",
+"188 429 OFFCURVE",
+"193 418 OFFCURVE",
+"202 414 CURVE SMOOTH",
+"212 409 OFFCURVE",
+"222 404 OFFCURVE",
+"231 404 CURVE SMOOTH",
+"236 404 OFFCURVE",
+"241 406 OFFCURVE",
+"245 410 CURVE SMOOTH",
+"252 417 OFFCURVE",
+"255 436 OFFCURVE",
+"255 454 CURVE SMOOTH",
+"255 469 OFFCURVE",
+"253 483 OFFCURVE",
+"247 489 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"210 97 OFFCURVE",
+"198 80 OFFCURVE",
+"181 62 CURVE SMOOTH",
+"168 49 OFFCURVE",
+"150 30 OFFCURVE",
+"113 32 CURVE SMOOTH",
+"95 32 OFFCURVE",
+"87 45 OFFCURVE",
+"87 64 CURVE SMOOTH",
+"87 93 OFFCURVE",
+"105 139 OFFCURVE",
+"133 184 CURVE SMOOTH",
+"159 228 OFFCURVE",
+"174 249 OFFCURVE",
+"189 291 CURVE SMOOTH",
+"191 296 OFFCURVE",
+"192 301 OFFCURVE",
+"192 305 CURVE SMOOTH",
+"192 321 OFFCURVE",
+"179 327 OFFCURVE",
+"166 327 CURVE SMOOTH",
+"157 327 OFFCURVE",
+"149 324 OFFCURVE",
+"146 318 CURVE SMOOTH",
+"124 279 OFFCURVE",
+"118 243 OFFCURVE",
+"106 205 CURVE",
+"84 172 OFFCURVE",
+"68 140 OFFCURVE",
+"-15 52 CURVE SMOOTH",
+"-19 48 OFFCURVE",
+"-21 43 OFFCURVE",
+"-21 38 CURVE SMOOTH",
+"-21 34 OFFCURVE",
+"-19 31 OFFCURVE",
+"-15 31 CURVE SMOOTH",
+"-13 31 OFFCURVE",
+"-10 32 OFFCURVE",
+"-7 34 CURVE",
+"17 53 OFFCURVE",
+"50 89 OFFCURVE",
+"63 113 CURVE",
+"59 98 OFFCURVE",
+"56 83 OFFCURVE",
+"56 69 CURVE SMOOTH",
+"56 37 OFFCURVE",
+"71 11 OFFCURVE",
+"121 11 CURVE SMOOTH",
+"170 11 OFFCURVE",
+"199 53 OFFCURVE",
+"219 82 CURVE SMOOTH",
+"223 87 OFFCURVE",
+"227 100 OFFCURVE",
+"227 107 CURVE SMOOTH",
+"227 111 OFFCURVE",
+"225 113 OFFCURVE",
+"221 109 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"261 535 OFFCURVE",
+"254 537 OFFCURVE",
+"248 537 CURVE SMOOTH",
+"241 537 OFFCURVE",
+"235 535 OFFCURVE",
+"229 529 CURVE SMOOTH",
+"214 514 OFFCURVE",
+"208 497 OFFCURVE",
+"208 483 CURVE SMOOTH",
+"208 469 OFFCURVE",
+"213 458 OFFCURVE",
+"222 454 CURVE SMOOTH",
+"232 449 OFFCURVE",
+"242 444 OFFCURVE",
+"251 444 CURVE SMOOTH",
+"256 444 OFFCURVE",
+"261 446 OFFCURVE",
+"265 450 CURVE SMOOTH",
+"272 457 OFFCURVE",
+"275 476 OFFCURVE",
+"275 494 CURVE SMOOTH",
+"275 509 OFFCURVE",
+"273 523 OFFCURVE",
+"267 529 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"210 97 OFFCURVE",
+"198 80 OFFCURVE",
+"181 62 CURVE SMOOTH",
+"168 49 OFFCURVE",
+"150 30 OFFCURVE",
+"113 32 CURVE SMOOTH",
+"95 32 OFFCURVE",
+"87 45 OFFCURVE",
+"87 64 CURVE SMOOTH",
+"87 93 OFFCURVE",
+"105 139 OFFCURVE",
+"133 184 CURVE SMOOTH",
+"159 228 OFFCURVE",
+"174 249 OFFCURVE",
+"189 291 CURVE SMOOTH",
+"191 296 OFFCURVE",
+"192 301 OFFCURVE",
+"192 305 CURVE SMOOTH",
+"192 321 OFFCURVE",
+"179 327 OFFCURVE",
+"166 327 CURVE SMOOTH",
+"157 327 OFFCURVE",
+"149 324 OFFCURVE",
+"146 318 CURVE SMOOTH",
+"124 279 OFFCURVE",
+"118 243 OFFCURVE",
+"106 205 CURVE",
+"84 172 OFFCURVE",
+"68 140 OFFCURVE",
+"-15 52 CURVE SMOOTH",
+"-19 48 OFFCURVE",
+"-21 43 OFFCURVE",
+"-21 38 CURVE SMOOTH",
+"-21 34 OFFCURVE",
+"-19 31 OFFCURVE",
+"-15 31 CURVE SMOOTH",
+"-13 31 OFFCURVE",
+"-10 32 OFFCURVE",
+"-7 34 CURVE",
+"17 53 OFFCURVE",
+"50 89 OFFCURVE",
+"63 113 CURVE",
+"59 98 OFFCURVE",
+"56 83 OFFCURVE",
+"56 69 CURVE SMOOTH",
+"56 37 OFFCURVE",
+"71 11 OFFCURVE",
+"121 11 CURVE SMOOTH",
+"170 11 OFFCURVE",
+"199 53 OFFCURVE",
+"219 82 CURVE SMOOTH",
+"223 87 OFFCURVE",
+"227 100 OFFCURVE",
+"227 107 CURVE SMOOTH",
+"227 111 OFFCURVE",
+"225 113 OFFCURVE",
+"221 109 CURVE SMOOTH"
+);
+}
+);
+width = 185;
+}
+);
+leftKerningGroup = i;
+note = i;
+rightKerningGroup = i;
 },
 {
 color = 3;
@@ -23714,142 +24098,6 @@ note = nine;
 rightKerningGroup = nine;
 },
 {
-glyphname = fraction;
-lastChange = "2022-02-04 13:16:50 +0000";
-layers = (
-{
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"383 529 OFFCURVE",
-"372 539 OFFCURVE",
-"361 539 CURVE SMOOTH",
-"354 539 OFFCURVE",
-"349 535 OFFCURVE",
-"345 530 CURVE SMOOTH",
-"334 517 OFFCURVE",
-"325 502 OFFCURVE",
-"315 489 CURVE SMOOTH",
-"289 454 OFFCURVE",
-"262 419 OFFCURVE",
-"236 384 CURVE SMOOTH",
-"158 279 OFFCURVE",
-"75 161 OFFCURVE",
-"30 37 CURVE SMOOTH",
-"29 34 OFFCURVE",
-"28 30 OFFCURVE",
-"28 27 CURVE SMOOTH",
-"28 23 OFFCURVE",
-"30 18 OFFCURVE",
-"35 18 CURVE SMOOTH",
-"46 18 OFFCURVE",
-"53 32 OFFCURVE",
-"57 40 CURVE SMOOTH",
-"61 50 OFFCURVE",
-"65 61 OFFCURVE",
-"69 71 CURVE SMOOTH",
-"83 104 OFFCURVE",
-"101 135 OFFCURVE",
-"120 166 CURVE SMOOTH",
-"171 247 OFFCURVE",
-"233 322 OFFCURVE",
-"293 396 CURVE SMOOTH",
-"322 432 OFFCURVE",
-"352 467 OFFCURVE",
-"379 505 CURVE",
-"381 509 OFFCURVE",
-"383 513 OFFCURVE",
-"383 518 CURVE SMOOTH"
-);
-}
-);
-width = 403;
-}
-);
-note = fraction;
-unicode = 2044;
-},
-{
-glyphname = onehalf;
-lastChange = "2022-02-04 13:16:50 +0000";
-layers = (
-{
-components = (
-{
-name = onesuperior;
-},
-{
-alignment = -1;
-name = fraction;
-transform = "{1, 0, 0, 1, 73, 0}";
-},
-{
-name = twosuperior;
-transform = "{1, 0, 0, 1, 266, -262}";
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 658;
-}
-);
-note = onehalf;
-unicode = 00BD;
-},
-{
-glyphname = onequarter;
-lastChange = "2022-02-04 13:16:50 +0000";
-layers = (
-{
-components = (
-{
-name = onesuperior;
-},
-{
-alignment = -1;
-name = fraction;
-transform = "{1, 0, 0, 1, 84, 0}";
-},
-{
-name = foursuperior;
-transform = "{1, 0, 0, 1, 259, -286}";
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 617;
-}
-);
-note = onequarter;
-unicode = 00BC;
-},
-{
-glyphname = threequarters;
-lastChange = "2022-02-04 13:16:50 +0000";
-layers = (
-{
-components = (
-{
-alignment = -1;
-name = fraction;
-transform = "{1, 0, 0, 1, 134, -18}";
-},
-{
-name = foursuperior;
-transform = "{1, 0, 0, 1, 330, -292}";
-},
-{
-name = threesuperior;
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 688;
-}
-);
-note = threequarters;
-unicode = 00BE;
-},
-{
 glyphname = onesuperior;
 lastChange = "2022-02-04 13:17:06 +0000";
 layers = (
@@ -24378,20 +24626,8 @@ width = 358;
 unicode = 2074;
 },
 {
-glyphname = CR;
-lastChange = "2022-02-04 13:23:02 +0000";
-layers = (
-{
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
-);
-note = CR;
-unicode = 000D;
-},
-{
-glyphname = .notdef;
-lastChange = "2021-11-24 07:09:24 +0000";
+glyphname = fraction;
+lastChange = "2022-02-04 13:16:50 +0000";
 layers = (
 {
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -24399,186 +24635,131 @@ paths = (
 {
 closed = 1;
 nodes = (
-"50 0 LINE",
-"424 0 LINE",
-"424 702 LINE",
-"50 702 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"369 674 LINE",
-"236 393 LINE",
-"102 674 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"387 638 LINE",
-"387 75 LINE",
-"253 357 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"85 77 LINE",
-"85 637 LINE",
-"218 357 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"370 40 LINE",
-"101 40 LINE",
-"236 322 LINE"
+"383 529 OFFCURVE",
+"372 539 OFFCURVE",
+"361 539 CURVE SMOOTH",
+"354 539 OFFCURVE",
+"349 535 OFFCURVE",
+"345 530 CURVE SMOOTH",
+"334 517 OFFCURVE",
+"325 502 OFFCURVE",
+"315 489 CURVE SMOOTH",
+"289 454 OFFCURVE",
+"262 419 OFFCURVE",
+"236 384 CURVE SMOOTH",
+"158 279 OFFCURVE",
+"75 161 OFFCURVE",
+"30 37 CURVE SMOOTH",
+"29 34 OFFCURVE",
+"28 30 OFFCURVE",
+"28 27 CURVE SMOOTH",
+"28 23 OFFCURVE",
+"30 18 OFFCURVE",
+"35 18 CURVE SMOOTH",
+"46 18 OFFCURVE",
+"53 32 OFFCURVE",
+"57 40 CURVE SMOOTH",
+"61 50 OFFCURVE",
+"65 61 OFFCURVE",
+"69 71 CURVE SMOOTH",
+"83 104 OFFCURVE",
+"101 135 OFFCURVE",
+"120 166 CURVE SMOOTH",
+"171 247 OFFCURVE",
+"233 322 OFFCURVE",
+"293 396 CURVE SMOOTH",
+"322 432 OFFCURVE",
+"352 467 OFFCURVE",
+"379 505 CURVE",
+"381 509 OFFCURVE",
+"383 513 OFFCURVE",
+"383 518 CURVE SMOOTH"
 );
 }
 );
-width = 474;
+width = 403;
 }
 );
-note = .notdef;
+note = fraction;
+unicode = 2044;
 },
 {
-glyphname = .null;
-lastChange = "2022-02-08 13:27:55 +0000";
+glyphname = onehalf;
+lastChange = "2022-02-04 13:16:50 +0000";
 layers = (
 {
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
-);
-note = NULL;
+components = (
+{
+name = onesuperior;
 },
 {
-glyphname = space;
-layers = (
-{
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 159;
-}
-);
-note = space;
-unicode = 0020;
+alignment = -1;
+name = fraction;
+transform = "{1, 0, 0, 1, 73, 0}";
 },
 {
-glyphname = nbspace;
-lastChange = "2022-02-04 13:24:02 +0000";
-layers = (
-{
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 159;
+name = twosuperior;
+transform = "{1, 0, 0, 1, 266, -262}";
 }
 );
-widthMetricsKey = space;
-note = nbspace;
-unicode = 00A0;
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 658;
+}
+);
+note = onehalf;
+unicode = 00BD;
 },
 {
-glyphname = "leftanglebracket-math";
-lastChange = "2022-02-04 13:17:06 +0000";
+glyphname = onequarter;
+lastChange = "2022-02-04 13:16:50 +0000";
 layers = (
 {
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
+components = (
 {
-closed = 1;
-nodes = (
-"435 667 OFFCURVE",
-"437 673 OFFCURVE",
-"437 679 CURVE SMOOTH",
-"437 688 OFFCURVE",
-"431 697 OFFCURVE",
-"424 697 CURVE SMOOTH",
-"421 697 OFFCURVE",
-"418 696 OFFCURVE",
-"415 693 CURVE SMOOTH",
-"312 601 OFFCURVE",
-"155 385 OFFCURVE",
-"91 297 CURVE SMOOTH",
-"85 289 OFFCURVE",
-"80 281 OFFCURVE",
-"80 274 CURVE SMOOTH",
-"80 271 OFFCURVE",
-"81 268 OFFCURVE",
-"84 265 CURVE SMOOTH",
-"140 177 OFFCURVE",
-"172 62 OFFCURVE",
-"235 -95 CURVE SMOOTH",
-"237 -100 OFFCURVE",
-"240 -102 OFFCURVE",
-"244 -102 CURVE SMOOTH",
-"255 -102 OFFCURVE",
-"270 -84 OFFCURVE",
-"264 -70 CURVE SMOOTH",
-"224 28 OFFCURVE",
-"190 183 OFFCURVE",
-"141 281 CURVE",
-"191 375 OFFCURVE",
-"337 580 OFFCURVE",
-"430 663 CURVE SMOOTH"
-);
-}
-);
-width = 457;
-}
-);
-unicode = 27E8;
+name = onesuperior;
 },
 {
-glyphname = "rightanglebracket-math";
-lastChange = "2022-02-04 13:17:06 +0000";
+alignment = -1;
+name = fraction;
+transform = "{1, 0, 0, 1, 84, 0}";
+},
+{
+name = foursuperior;
+transform = "{1, 0, 0, 1, 259, -286}";
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 617;
+}
+);
+note = onequarter;
+unicode = 00BC;
+},
+{
+glyphname = threequarters;
+lastChange = "2022-02-04 13:16:50 +0000";
 layers = (
 {
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
+components = (
 {
-closed = 1;
-nodes = (
-"22 -72 OFFCURVE",
-"20 -78 OFFCURVE",
-"20 -84 CURVE SMOOTH",
-"20 -93 OFFCURVE",
-"26 -102 OFFCURVE",
-"33 -102 CURVE SMOOTH",
-"36 -102 OFFCURVE",
-"39 -101 OFFCURVE",
-"42 -98 CURVE SMOOTH",
-"145 -6 OFFCURVE",
-"302 210 OFFCURVE",
-"366 298 CURVE SMOOTH",
-"372 306 OFFCURVE",
-"377 314 OFFCURVE",
-"377 321 CURVE SMOOTH",
-"377 324 OFFCURVE",
-"376 327 OFFCURVE",
-"373 330 CURVE SMOOTH",
-"317 418 OFFCURVE",
-"285 533 OFFCURVE",
-"222 690 CURVE SMOOTH",
-"220 695 OFFCURVE",
-"217 697 OFFCURVE",
-"213 697 CURVE SMOOTH",
-"202 697 OFFCURVE",
-"187 679 OFFCURVE",
-"193 665 CURVE SMOOTH",
-"233 567 OFFCURVE",
-"267 412 OFFCURVE",
-"316 314 CURVE",
-"266 220 OFFCURVE",
-"120 15 OFFCURVE",
-"27 -68 CURVE SMOOTH"
-);
+alignment = -1;
+name = fraction;
+transform = "{1, 0, 0, 1, 134, -18}";
+},
+{
+name = foursuperior;
+transform = "{1, 0, 0, 1, 330, -292}";
+},
+{
+name = threesuperior;
 }
 );
-width = 457;
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 688;
 }
 );
-unicode = 27E9;
+note = threequarters;
+unicode = 00BE;
 },
 {
 glyphname = period;
@@ -25708,47 +25889,6 @@ note = backslash;
 unicode = 005C;
 },
 {
-glyphname = periodcentered.loclCAT;
-lastChange = "2022-02-08 10:20:27 +0000";
-layers = (
-{
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"-6 246 OFFCURVE",
-"-20 254 OFFCURVE",
-"-30 254 CURVE SMOOTH",
-"-36 254 OFFCURVE",
-"-42 251 OFFCURVE",
-"-44 244 CURVE SMOOTH",
-"-48 234 OFFCURVE",
-"-64 222 OFFCURVE",
-"-64 208 CURVE SMOOTH",
-"-64 206 OFFCURVE",
-"-63 203 OFFCURVE",
-"-62 200 CURVE SMOOTH",
-"-57 188 OFFCURVE",
-"-47 184 OFFCURVE",
-"-36 184 CURVE SMOOTH",
-"-30 184 OFFCURVE",
-"-23 185 OFFCURVE",
-"-17 188 CURVE SMOOTH",
-"-4 194 OFFCURVE",
-"5 208 OFFCURVE",
-"5 222 CURVE SMOOTH",
-"5 228 OFFCURVE",
-"3 233 OFFCURVE",
-"0 238 CURVE SMOOTH"
-);
-}
-);
-width = 0;
-}
-);
-},
-{
 color = 3;
 glyphname = periodcentered.loclCAT.case;
 lastChange = "2022-02-08 10:21:12 +0000";
@@ -25791,8 +25931,8 @@ width = 0;
 );
 },
 {
-glyphname = hyphen;
-lastChange = "2022-02-10 15:58:52 +0000";
+glyphname = periodcentered.loclCAT;
+lastChange = "2022-02-08 10:20:27 +0000";
 layers = (
 {
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -25800,290 +25940,36 @@ paths = (
 {
 closed = 1;
 nodes = (
-"262 182 OFFCURVE",
-"247 185 OFFCURVE",
-"222 185 CURVE SMOOTH",
-"194 185 OFFCURVE",
-"163 185 OFFCURVE",
-"128 185 CURVE SMOOTH",
-"110 185 OFFCURVE",
-"84 180 OFFCURVE",
-"71 180 CURVE SMOOTH",
-"63 180 OFFCURVE",
-"60 177 OFFCURVE",
-"60 173 CURVE SMOOTH",
-"60 168 OFFCURVE",
-"65 162 OFFCURVE",
-"73 158 CURVE SMOOTH",
-"78 156 OFFCURVE",
-"86 155 OFFCURVE",
-"94 155 CURVE SMOOTH",
-"103 155 OFFCURVE",
-"114 156 OFFCURVE",
-"123 156 CURVE SMOOTH",
-"128 156 OFFCURVE",
-"132 156 OFFCURVE",
-"136 155 CURVE",
-"160 153 OFFCURVE",
-"233 152 OFFCURVE",
-"259 152 CURVE SMOOTH",
-"269 152 OFFCURVE",
-"278 160 OFFCURVE",
-"278 168 CURVE SMOOTH",
-"278 172 OFFCURVE",
-"275 176 OFFCURVE",
-"269 178 CURVE"
+"-6 246 OFFCURVE",
+"-20 254 OFFCURVE",
+"-30 254 CURVE SMOOTH",
+"-36 254 OFFCURVE",
+"-42 251 OFFCURVE",
+"-44 244 CURVE SMOOTH",
+"-48 234 OFFCURVE",
+"-64 222 OFFCURVE",
+"-64 208 CURVE SMOOTH",
+"-64 206 OFFCURVE",
+"-63 203 OFFCURVE",
+"-62 200 CURVE SMOOTH",
+"-57 188 OFFCURVE",
+"-47 184 OFFCURVE",
+"-36 184 CURVE SMOOTH",
+"-30 184 OFFCURVE",
+"-23 185 OFFCURVE",
+"-17 188 CURVE SMOOTH",
+"-4 194 OFFCURVE",
+"5 208 OFFCURVE",
+"5 222 CURVE SMOOTH",
+"5 228 OFFCURVE",
+"3 233 OFFCURVE",
+"0 238 CURVE SMOOTH"
 );
 }
 );
-width = 326;
+width = 0;
 }
 );
-leftKerningGroup = hyphen;
-note = hyphen;
-rightKerningGroup = hyphen;
-unicode = 002D;
-},
-{
-color = 3;
-glyphname = softhyphen;
-lastChange = "2022-02-10 14:29:43 +0000";
-layers = (
-{
-components = (
-{
-name = hyphen;
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 326;
-}
-);
-leftKerningGroup = hyphen;
-leftMetricsKey = hyphen;
-rightKerningGroup = hyphen;
-rightMetricsKey = hyphen;
-unicode = 00AD;
-},
-{
-color = 3;
-glyphname = endash;
-lastChange = "2022-02-10 14:29:43 +0000";
-layers = (
-{
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"374 182 OFFCURVE",
-"363 185 OFFCURVE",
-"344 185 CURVE SMOOTH",
-"322 185 OFFCURVE",
-"229 185 OFFCURVE",
-"134 185 CURVE SMOOTH",
-"98 185 OFFCURVE",
-"78 180 OFFCURVE",
-"68 180 CURVE SMOOTH",
-"62 180 OFFCURVE",
-"60 177 OFFCURVE",
-"60 173 CURVE SMOOTH",
-"60 168 OFFCURVE",
-"64 162 OFFCURVE",
-"70 158 CURVE SMOOTH",
-"74 156 OFFCURVE",
-"80 155 OFFCURVE",
-"86 155 CURVE SMOOTH",
-"93 155 OFFCURVE",
-"101 156 OFFCURVE",
-"130 156 CURVE SMOOTH",
-"134 156 OFFCURVE",
-"171 156 OFFCURVE",
-"209 155 CURVE",
-"227 153 OFFCURVE",
-"352 152 OFFCURVE",
-"372 152 CURVE SMOOTH",
-"380 152 OFFCURVE",
-"387 160 OFFCURVE",
-"387 168 CURVE SMOOTH",
-"387 172 OFFCURVE",
-"384 176 OFFCURVE",
-"380 178 CURVE"
-);
-}
-);
-width = 435;
-}
-);
-leftKerningGroup = hyphen;
-leftMetricsKey = hyphen;
-note = endash;
-rightKerningGroup = hyphen;
-rightMetricsKey = hyphen;
-unicode = 2013;
-},
-{
-color = 3;
-glyphname = emdash;
-lastChange = "2022-02-10 14:29:43 +0000";
-layers = (
-{
-background = {
-hints = (
-{
-horizontal = 1;
-place = "{154, 33}";
-type = Stem;
-}
-);
-paths = (
-{
-closed = 1;
-nodes = (
-"469 186 OFFCURVE",
-"391 176 OFFCURVE",
-"378 192 CURVE",
-"202 182 LINE",
-"185 184 OFFCURVE",
-"86 176 OFFCURVE",
-"73 180 CURVE SMOOTH",
-"57 185 OFFCURVE",
-"61 165 OFFCURVE",
-"76 158 CURVE SMOOTH",
-"91 152 OFFCURVE",
-"187 158 OFFCURVE",
-"202 155 CURVE",
-"347 153 LINE",
-"352 144 OFFCURVE",
-"434 156 OFFCURVE",
-"445 151 CURVE SMOOTH",
-"460 143 OFFCURVE",
-"494 175 OFFCURVE",
-"477 183 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"472 182 OFFCURVE",
-"457 185 OFFCURVE",
-"432 185 CURVE SMOOTH",
-"404 185 OFFCURVE",
-"282 185 OFFCURVE",
-"157 185 CURVE SMOOTH",
-"110 185 OFFCURVE",
-"84 180 OFFCURVE",
-"71 180 CURVE SMOOTH",
-"63 180 OFFCURVE",
-"60 177 OFFCURVE",
-"60 173 CURVE SMOOTH",
-"60 168 OFFCURVE",
-"65 162 OFFCURVE",
-"73 158 CURVE SMOOTH",
-"78 156 OFFCURVE",
-"86 155 OFFCURVE",
-"94 155 CURVE SMOOTH",
-"103 155 OFFCURVE",
-"114 156 OFFCURVE",
-"152 156 CURVE SMOOTH",
-"157 156 OFFCURVE",
-"205 156 OFFCURVE",
-"255 155 CURVE",
-"279 153 OFFCURVE",
-"443 152 OFFCURVE",
-"469 152 CURVE SMOOTH",
-"479 152 OFFCURVE",
-"488 160 OFFCURVE",
-"488 168 CURVE SMOOTH",
-"488 172 OFFCURVE",
-"485 176 OFFCURVE",
-"479 178 CURVE"
-);
-}
-);
-width = 536;
-}
-);
-leftKerningGroup = hyphen;
-leftMetricsKey = hyphen;
-note = emdash;
-rightKerningGroup = hyphen;
-rightMetricsKey = hyphen;
-unicode = 2014;
-},
-{
-color = 3;
-glyphname = hyphentwo;
-lastChange = "2022-02-10 14:29:43 +0000";
-layers = (
-{
-components = (
-{
-name = hyphen;
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 326;
-}
-);
-leftKerningGroup = hyphen;
-leftMetricsKey = hyphen;
-rightKerningGroup = hyphen;
-rightMetricsKey = hyphen;
-unicode = 2010;
-},
-{
-glyphname = underscore;
-lastChange = "2022-02-08 10:16:46 +0000";
-layers = (
-{
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"44 -41 LINE SMOOTH",
-"127 -39 OFFCURVE",
-"317 -34 OFFCURVE",
-"447 -31 CURVE SMOOTH",
-"503 -30 OFFCURVE",
-"508 -30 OFFCURVE",
-"565 -29 CURVE",
-"570 -28 OFFCURVE",
-"606 -27 OFFCURVE",
-"606 -20 CURVE SMOOTH",
-"606 -14 OFFCURVE",
-"570 -11 OFFCURVE",
-"565 -11 CURVE SMOOTH",
-"523 -6 OFFCURVE",
-"530 -7 OFFCURVE",
-"488 -6 CURVE SMOOTH",
-"406 -4 OFFCURVE",
-"213 -3 OFFCURVE",
-"160 -3 CURVE SMOOTH",
-"141 -3 OFFCURVE",
-"70 -2 OFFCURVE",
-"54 -8 CURVE SMOOTH",
-"46 -11 OFFCURVE",
-"19 -23 OFFCURVE",
-"19 -34 CURVE SMOOTH",
-"19 -41 OFFCURVE",
-"36 -41 OFFCURVE",
-"39 -41 CURVE SMOOTH"
-);
-}
-);
-width = 611;
-}
-);
-leftKerningGroup = period;
-note = underscore;
-rightKerningGroup = period;
-unicode = 005F;
 },
 {
 glyphname = parenleft;
@@ -26531,6 +26417,301 @@ width = 310;
 );
 note = bracketright;
 unicode = 005D;
+},
+{
+glyphname = hyphen;
+lastChange = "2022-02-10 15:58:52 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"262 182 OFFCURVE",
+"247 185 OFFCURVE",
+"222 185 CURVE SMOOTH",
+"194 185 OFFCURVE",
+"163 185 OFFCURVE",
+"128 185 CURVE SMOOTH",
+"110 185 OFFCURVE",
+"84 180 OFFCURVE",
+"71 180 CURVE SMOOTH",
+"63 180 OFFCURVE",
+"60 177 OFFCURVE",
+"60 173 CURVE SMOOTH",
+"60 168 OFFCURVE",
+"65 162 OFFCURVE",
+"73 158 CURVE SMOOTH",
+"78 156 OFFCURVE",
+"86 155 OFFCURVE",
+"94 155 CURVE SMOOTH",
+"103 155 OFFCURVE",
+"114 156 OFFCURVE",
+"123 156 CURVE SMOOTH",
+"128 156 OFFCURVE",
+"132 156 OFFCURVE",
+"136 155 CURVE",
+"160 153 OFFCURVE",
+"233 152 OFFCURVE",
+"259 152 CURVE SMOOTH",
+"269 152 OFFCURVE",
+"278 160 OFFCURVE",
+"278 168 CURVE SMOOTH",
+"278 172 OFFCURVE",
+"275 176 OFFCURVE",
+"269 178 CURVE"
+);
+}
+);
+width = 326;
+}
+);
+leftKerningGroup = hyphen;
+note = hyphen;
+rightKerningGroup = hyphen;
+unicode = 002D;
+},
+{
+color = 3;
+glyphname = softhyphen;
+lastChange = "2022-02-10 14:29:43 +0000";
+layers = (
+{
+components = (
+{
+name = hyphen;
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 326;
+}
+);
+leftKerningGroup = hyphen;
+leftMetricsKey = hyphen;
+rightKerningGroup = hyphen;
+rightMetricsKey = hyphen;
+unicode = 00AD;
+},
+{
+color = 3;
+glyphname = endash;
+lastChange = "2022-02-10 14:29:43 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"374 182 OFFCURVE",
+"363 185 OFFCURVE",
+"344 185 CURVE SMOOTH",
+"322 185 OFFCURVE",
+"229 185 OFFCURVE",
+"134 185 CURVE SMOOTH",
+"98 185 OFFCURVE",
+"78 180 OFFCURVE",
+"68 180 CURVE SMOOTH",
+"62 180 OFFCURVE",
+"60 177 OFFCURVE",
+"60 173 CURVE SMOOTH",
+"60 168 OFFCURVE",
+"64 162 OFFCURVE",
+"70 158 CURVE SMOOTH",
+"74 156 OFFCURVE",
+"80 155 OFFCURVE",
+"86 155 CURVE SMOOTH",
+"93 155 OFFCURVE",
+"101 156 OFFCURVE",
+"130 156 CURVE SMOOTH",
+"134 156 OFFCURVE",
+"171 156 OFFCURVE",
+"209 155 CURVE",
+"227 153 OFFCURVE",
+"352 152 OFFCURVE",
+"372 152 CURVE SMOOTH",
+"380 152 OFFCURVE",
+"387 160 OFFCURVE",
+"387 168 CURVE SMOOTH",
+"387 172 OFFCURVE",
+"384 176 OFFCURVE",
+"380 178 CURVE"
+);
+}
+);
+width = 435;
+}
+);
+leftKerningGroup = hyphen;
+leftMetricsKey = hyphen;
+note = endash;
+rightKerningGroup = hyphen;
+rightMetricsKey = hyphen;
+unicode = 2013;
+},
+{
+color = 3;
+glyphname = emdash;
+lastChange = "2022-02-10 14:29:43 +0000";
+layers = (
+{
+background = {
+hints = (
+{
+horizontal = 1;
+place = "{154, 33}";
+type = Stem;
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"469 186 OFFCURVE",
+"391 176 OFFCURVE",
+"378 192 CURVE",
+"202 182 LINE",
+"185 184 OFFCURVE",
+"86 176 OFFCURVE",
+"73 180 CURVE SMOOTH",
+"57 185 OFFCURVE",
+"61 165 OFFCURVE",
+"76 158 CURVE SMOOTH",
+"91 152 OFFCURVE",
+"187 158 OFFCURVE",
+"202 155 CURVE",
+"347 153 LINE",
+"352 144 OFFCURVE",
+"434 156 OFFCURVE",
+"445 151 CURVE SMOOTH",
+"460 143 OFFCURVE",
+"494 175 OFFCURVE",
+"477 183 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"472 182 OFFCURVE",
+"457 185 OFFCURVE",
+"432 185 CURVE SMOOTH",
+"404 185 OFFCURVE",
+"282 185 OFFCURVE",
+"157 185 CURVE SMOOTH",
+"110 185 OFFCURVE",
+"84 180 OFFCURVE",
+"71 180 CURVE SMOOTH",
+"63 180 OFFCURVE",
+"60 177 OFFCURVE",
+"60 173 CURVE SMOOTH",
+"60 168 OFFCURVE",
+"65 162 OFFCURVE",
+"73 158 CURVE SMOOTH",
+"78 156 OFFCURVE",
+"86 155 OFFCURVE",
+"94 155 CURVE SMOOTH",
+"103 155 OFFCURVE",
+"114 156 OFFCURVE",
+"152 156 CURVE SMOOTH",
+"157 156 OFFCURVE",
+"205 156 OFFCURVE",
+"255 155 CURVE",
+"279 153 OFFCURVE",
+"443 152 OFFCURVE",
+"469 152 CURVE SMOOTH",
+"479 152 OFFCURVE",
+"488 160 OFFCURVE",
+"488 168 CURVE SMOOTH",
+"488 172 OFFCURVE",
+"485 176 OFFCURVE",
+"479 178 CURVE"
+);
+}
+);
+width = 536;
+}
+);
+leftKerningGroup = hyphen;
+leftMetricsKey = hyphen;
+note = emdash;
+rightKerningGroup = hyphen;
+rightMetricsKey = hyphen;
+unicode = 2014;
+},
+{
+color = 3;
+glyphname = hyphentwo;
+lastChange = "2022-02-10 14:29:43 +0000";
+layers = (
+{
+components = (
+{
+name = hyphen;
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 326;
+}
+);
+leftKerningGroup = hyphen;
+leftMetricsKey = hyphen;
+rightKerningGroup = hyphen;
+rightMetricsKey = hyphen;
+unicode = 2010;
+},
+{
+glyphname = underscore;
+lastChange = "2022-02-08 10:16:46 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"44 -41 LINE SMOOTH",
+"127 -39 OFFCURVE",
+"317 -34 OFFCURVE",
+"447 -31 CURVE SMOOTH",
+"503 -30 OFFCURVE",
+"508 -30 OFFCURVE",
+"565 -29 CURVE",
+"570 -28 OFFCURVE",
+"606 -27 OFFCURVE",
+"606 -20 CURVE SMOOTH",
+"606 -14 OFFCURVE",
+"570 -11 OFFCURVE",
+"565 -11 CURVE SMOOTH",
+"523 -6 OFFCURVE",
+"530 -7 OFFCURVE",
+"488 -6 CURVE SMOOTH",
+"406 -4 OFFCURVE",
+"213 -3 OFFCURVE",
+"160 -3 CURVE SMOOTH",
+"141 -3 OFFCURVE",
+"70 -2 OFFCURVE",
+"54 -8 CURVE SMOOTH",
+"46 -11 OFFCURVE",
+"19 -23 OFFCURVE",
+"19 -34 CURVE SMOOTH",
+"19 -41 OFFCURVE",
+"36 -41 OFFCURVE",
+"39 -41 CURVE SMOOTH"
+);
+}
+);
+width = 611;
+}
+);
+leftKerningGroup = period;
+note = underscore;
+rightKerningGroup = period;
+unicode = 005F;
 },
 {
 glyphname = quotesinglbase;
@@ -27568,8 +27749,8 @@ rightKerningGroup = quotes;
 unicode = 0027;
 },
 {
-glyphname = florin;
-lastChange = "2022-02-07 15:17:40 +0000";
+glyphname = "leftanglebracket-math";
+lastChange = "2022-02-04 13:17:06 +0000";
 layers = (
 {
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -27577,115 +27758,50 @@ paths = (
 {
 closed = 1;
 nodes = (
-"234 286 OFFCURVE",
-"241 302 OFFCURVE",
-"241 308 CURVE SMOOTH",
-"241 312 OFFCURVE",
-"239 317 OFFCURVE",
-"233 317 CURVE SMOOTH",
-"214 317 OFFCURVE",
-"196 320 OFFCURVE",
-"178 322 CURVE",
-"196 389 OFFCURVE",
-"215 451 OFFCURVE",
-"220 463 CURVE SMOOTH",
-"226 478 OFFCURVE",
-"271 592 OFFCURVE",
-"293 592 CURVE SMOOTH",
-"313 592 OFFCURVE",
-"311 578 OFFCURVE",
-"312 564 CURVE SMOOTH",
-"312 560 OFFCURVE",
-"314 556 OFFCURVE",
-"314 553 CURVE SMOOTH",
-"314 544 OFFCURVE",
-"297 512 OFFCURVE",
-"297 503 CURVE SMOOTH",
-"297 497 OFFCURVE",
-"299 488 OFFCURVE",
-"308 488 CURVE SMOOTH",
-"320 488 OFFCURVE",
-"326 505 OFFCURVE",
-"329 514 CURVE SMOOTH",
-"334 530 OFFCURVE",
-"338 528 OFFCURVE",
-"338 549 CURVE SMOOTH",
-"338 590 OFFCURVE",
-"324 611 OFFCURVE",
-"281 611 CURVE SMOOTH",
-"267 611 OFFCURVE",
-"257 605 OFFCURVE",
-"248 595 CURVE SMOOTH",
-"203 546 OFFCURVE",
-"192 494 OFFCURVE",
-"172 429 CURVE SMOOTH",
-"160 391 OFFCURVE",
-"149 357 OFFCURVE",
-"140 325 CURVE",
-"136 325 LINE SMOOTH",
-"105 325 OFFCURVE",
-"53 311 OFFCURVE",
-"53 285 CURVE SMOOTH",
-"53 283 OFFCURVE",
-"55 280 OFFCURVE",
-"60 280 CURVE SMOOTH",
-"64 280 OFFCURVE",
-"66 280 OFFCURVE",
-"69 281 CURVE SMOOTH",
-"88 288 OFFCURVE",
-"109 291 OFFCURVE",
-"131 292 CURVE",
-"119 249 OFFCURVE",
-"108 207 OFFCURVE",
-"96 158 CURVE SMOOTH",
-"86 120 OFFCURVE",
-"59 35 OFFCURVE",
-"43 -1 CURVE SMOOTH",
-"36 -15 OFFCURVE",
-"-3 -93 OFFCURVE",
-"-22 -104 CURVE SMOOTH",
-"-32 -110 OFFCURVE",
-"-40 -112 OFFCURVE",
-"-45 -112 CURVE SMOOTH",
-"-54 -112 OFFCURVE",
-"-58 -105 OFFCURVE",
-"-58 -95 CURVE SMOOTH",
-"-58 -75 OFFCURVE",
-"-42 -42 OFFCURVE",
-"-36 -37 CURVE",
-"-35 -32 OFFCURVE",
-"-37 -22 OFFCURVE",
-"-46 -22 CURVE SMOOTH",
-"-66 -22 OFFCURVE",
-"-78 -67 OFFCURVE",
-"-78 -82 CURVE SMOOTH",
-"-80 -124 OFFCURVE",
-"-66 -146 OFFCURVE",
-"-21 -146 CURVE SMOOTH",
-"-9 -146 OFFCURVE",
-"1 -140 OFFCURVE",
-"10 -131 CURVE SMOOTH",
-"57 -84 OFFCURVE",
-"119 90 OFFCURVE",
-"134 156 CURVE SMOOTH",
-"138 177 OFFCURVE",
-"153 232 OFFCURVE",
-"169 290 CURVE",
-"187 288 OFFCURVE",
-"205 286 OFFCURVE",
-"223 286 CURVE SMOOTH"
+"435 667 OFFCURVE",
+"437 673 OFFCURVE",
+"437 679 CURVE SMOOTH",
+"437 688 OFFCURVE",
+"431 697 OFFCURVE",
+"424 697 CURVE SMOOTH",
+"421 697 OFFCURVE",
+"418 696 OFFCURVE",
+"415 693 CURVE SMOOTH",
+"312 601 OFFCURVE",
+"155 385 OFFCURVE",
+"91 297 CURVE SMOOTH",
+"85 289 OFFCURVE",
+"80 281 OFFCURVE",
+"80 274 CURVE SMOOTH",
+"80 271 OFFCURVE",
+"81 268 OFFCURVE",
+"84 265 CURVE SMOOTH",
+"140 177 OFFCURVE",
+"172 62 OFFCURVE",
+"235 -95 CURVE SMOOTH",
+"237 -100 OFFCURVE",
+"240 -102 OFFCURVE",
+"244 -102 CURVE SMOOTH",
+"255 -102 OFFCURVE",
+"270 -84 OFFCURVE",
+"264 -70 CURVE SMOOTH",
+"224 28 OFFCURVE",
+"190 183 OFFCURVE",
+"141 281 CURVE",
+"191 375 OFFCURVE",
+"337 580 OFFCURVE",
+"430 663 CURVE SMOOTH"
 );
 }
 );
-width = 257;
+width = 457;
 }
 );
-note = florin;
-unicode = 0192;
+unicode = 27E8;
 },
 {
-glyphname = apple;
-lastChange = "2022-02-07 15:17:40 +0000";
+glyphname = "rightanglebracket-math";
+lastChange = "2022-02-04 13:17:06 +0000";
 layers = (
 {
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -27693,98 +27809,86 @@ paths = (
 {
 closed = 1;
 nodes = (
-"362 101 OFFCURVE",
-"384 124 OFFCURVE",
-"409 154 CURVE SMOOTH",
-"428 177 OFFCURVE",
-"448 207 OFFCURVE",
-"459 241 CURVE",
-"416 258 OFFCURVE",
-"387 301 OFFCURVE",
-"387 351 CURVE SMOOTH",
-"387 406 OFFCURVE",
-"418 439 OFFCURVE",
-"445 454 CURVE",
-"417 500 OFFCURVE",
-"374 510 OFFCURVE",
-"347 510 CURVE SMOOTH",
-"337 510 OFFCURVE",
-"329 509 OFFCURVE",
-"325 507 CURVE SMOOTH",
-"314 503 OFFCURVE",
-"289 495 OFFCURVE",
-"269 489 CURVE SMOOTH",
-"261 487 OFFCURVE",
-"253 485 OFFCURVE",
-"245 485 CURVE SMOOTH",
-"238 485 OFFCURVE",
-"231 486 OFFCURVE",
-"224 488 CURVE SMOOTH",
-"204 494 OFFCURVE",
-"179 503 OFFCURVE",
-"169 507 CURVE SMOOTH",
-"165 508 OFFCURVE",
-"159 509 OFFCURVE",
-"151 509 CURVE SMOOTH",
-"123 509 OFFCURVE",
-"75 497 OFFCURVE",
-"43 438 CURVE SMOOTH",
-"27 409 OFFCURVE",
-"21 375 OFFCURVE",
-"21 340 CURVE SMOOTH",
-"21 272 OFFCURVE",
-"46 200 OFFCURVE",
-"84 154 CURVE SMOOTH",
-"109 124 OFFCURVE",
-"130 101 OFFCURVE",
-"157 101 CURVE SMOOTH",
-"184 101 OFFCURVE",
-"197 110 OFFCURVE",
-"205 115 CURVE SMOOTH",
-"215 122 OFFCURVE",
-"231 125 OFFCURVE",
-"247 125 CURVE SMOOTH",
-"262 125 OFFCURVE",
-"278 122 OFFCURVE",
-"288 115 CURVE SMOOTH",
-"297 110 OFFCURVE",
-"310 101 OFFCURVE",
-"336 101 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"267 501 OFFCURVE",
-"300 506 OFFCURVE",
-"326 544 CURVE SMOOTH",
-"344 570 OFFCURVE",
-"350 598 OFFCURVE",
-"350 616 CURVE SMOOTH",
-"350 623 OFFCURVE",
-"349 629 OFFCURVE",
-"347 632 CURVE",
-"335 637 OFFCURVE",
-"293 619 OFFCURVE",
-"271 587 CURVE SMOOTH",
-"254 561 OFFCURVE",
-"248 532 OFFCURVE",
-"248 514 CURVE SMOOTH",
-"248 509 OFFCURVE",
-"248 504 OFFCURVE",
-"249 501 CURVE"
+"22 -72 OFFCURVE",
+"20 -78 OFFCURVE",
+"20 -84 CURVE SMOOTH",
+"20 -93 OFFCURVE",
+"26 -102 OFFCURVE",
+"33 -102 CURVE SMOOTH",
+"36 -102 OFFCURVE",
+"39 -101 OFFCURVE",
+"42 -98 CURVE SMOOTH",
+"145 -6 OFFCURVE",
+"302 210 OFFCURVE",
+"366 298 CURVE SMOOTH",
+"372 306 OFFCURVE",
+"377 314 OFFCURVE",
+"377 321 CURVE SMOOTH",
+"377 324 OFFCURVE",
+"376 327 OFFCURVE",
+"373 330 CURVE SMOOTH",
+"317 418 OFFCURVE",
+"285 533 OFFCURVE",
+"222 690 CURVE SMOOTH",
+"220 695 OFFCURVE",
+"217 697 OFFCURVE",
+"213 697 CURVE SMOOTH",
+"202 697 OFFCURVE",
+"187 679 OFFCURVE",
+"193 665 CURVE SMOOTH",
+"233 567 OFFCURVE",
+"267 412 OFFCURVE",
+"316 314 CURVE",
+"266 220 OFFCURVE",
+"120 15 OFFCURVE",
+"27 -68 CURVE SMOOTH"
 );
 }
 );
-width = 478;
+width = 457;
 }
 );
-note = apple;
-unicode = F8FF;
+unicode = 27E9;
 },
 {
-glyphname = at;
-lastChange = "2022-02-10 16:18:31 +0000";
+glyphname = space;
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 159;
+}
+);
+note = space;
+unicode = 0020;
+},
+{
+glyphname = nbspace;
+lastChange = "2022-02-04 13:24:02 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 159;
+}
+);
+widthMetricsKey = space;
+note = nbspace;
+unicode = 00A0;
+},
+{
+glyphname = CR;
+lastChange = "2022-02-04 13:23:02 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
+note = CR;
+unicode = 000D;
+},
+{
+glyphname = .notdef;
+lastChange = "2021-11-24 07:09:24 +0000";
 layers = (
 {
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -27792,1771 +27896,60 @@ paths = (
 {
 closed = 1;
 nodes = (
-"498 260 OFFCURVE",
-"360 311 OFFCURVE",
-"259 311 CURVE SMOOTH",
-"163 311 OFFCURVE",
-"40 205 OFFCURVE",
-"40 106 CURVE SMOOTH",
-"40 25 OFFCURVE",
-"80 -119 OFFCURVE",
-"182 -119 CURVE SMOOTH",
-"215 -119 OFFCURVE",
-"265 -103 OFFCURVE",
-"285 -75 CURVE SMOOTH",
-"287 -72 OFFCURVE",
-"290 -67 OFFCURVE",
-"290 -63 CURVE SMOOTH",
-"290 -60 OFFCURVE",
-"288 -59 OFFCURVE",
-"286 -59 CURVE SMOOTH",
-"268 -59 OFFCURVE",
-"215 -95 OFFCURVE",
-"199 -95 CURVE SMOOTH",
-"113 -95 OFFCURVE",
-"80 15 OFFCURVE",
-"80 85 CURVE SMOOTH",
-"80 195 OFFCURVE",
-"141 285 OFFCURVE",
-"259 285 CURVE SMOOTH",
-"346 285 OFFCURVE",
-"455 244 OFFCURVE",
-"455 141 CURVE SMOOTH",
-"455 84 OFFCURVE",
-"452 9 OFFCURVE",
-"377 9 CURVE SMOOTH",
-"333 9 OFFCURVE",
-"344 111 OFFCURVE",
-"328 111 CURVE SMOOTH",
-"309 111 OFFCURVE",
-"264 11 OFFCURVE",
-"214 11 CURVE SMOOTH",
-"201 11 OFFCURVE",
-"196 71 OFFCURVE",
-"196 79 CURVE SMOOTH",
-"196 126 OFFCURVE",
-"214 171 OFFCURVE",
-"268 171 CURVE SMOOTH",
-"299 171 OFFCURVE",
-"330 164 OFFCURVE",
-"330 127 CURVE SMOOTH",
-"330 119 OFFCURVE",
-"335 114 OFFCURVE",
-"343 114 CURVE SMOOTH",
-"350 114 OFFCURVE",
-"356 119 OFFCURVE",
-"356 127 CURVE SMOOTH",
-"356 180 OFFCURVE",
-"314 197 OFFCURVE",
-"268 197 CURVE SMOOTH",
-"196 197 OFFCURVE",
-"153 137 OFFCURVE",
-"153 69 CURVE SMOOTH",
-"153 32 OFFCURVE",
-"170 -15 OFFCURVE",
-"214 -15 CURVE SMOOTH",
-"247 -15 OFFCURVE",
-"287 17 OFFCURVE",
-"307 41 CURVE",
-"319 7 OFFCURVE",
-"350 -4 OFFCURVE",
-"384 -4 CURVE SMOOTH",
-"473 -4 OFFCURVE",
-"498 63 OFFCURVE",
-"498 140 CURVE SMOOTH"
+"50 0 LINE",
+"424 0 LINE",
+"424 702 LINE",
+"50 702 LINE"
 );
-}
-);
-width = 544;
-}
-);
-note = at;
-unicode = 0040;
 },
 {
-glyphname = ampersand;
-lastChange = "2022-02-08 12:52:23 +0000";
+closed = 1;
+nodes = (
+"369 674 LINE",
+"236 393 LINE",
+"102 674 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"387 638 LINE",
+"387 75 LINE",
+"253 357 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"85 77 LINE",
+"85 637 LINE",
+"218 357 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"370 40 LINE",
+"101 40 LINE",
+"236 322 LINE"
+);
+}
+);
+width = 474;
+}
+);
+note = .notdef;
+},
+{
+glyphname = .null;
+lastChange = "2022-02-08 13:27:55 +0000";
 layers = (
 {
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"641 37 OFFCURVE",
-"618 31 OFFCURVE",
-"596 31 CURVE SMOOTH",
-"579 31 OFFCURVE",
-"562 34 OFFCURVE",
-"546 40 CURVE",
-"591 77 OFFCURVE",
-"625 126 OFFCURVE",
-"625 177 CURVE SMOOTH",
-"625 303 OFFCURVE",
-"522 385 OFFCURVE",
-"403 385 CURVE SMOOTH",
-"341 385 OFFCURVE",
-"277 349 OFFCURVE",
-"239 296 CURVE",
-"217 331 OFFCURVE",
-"201 371 OFFCURVE",
-"193 409 CURVE",
-"202 417 OFFCURVE",
-"211 425 OFFCURVE",
-"222 433 CURVE SMOOTH",
-"278 475 OFFCURVE",
-"381 505 OFFCURVE",
-"425 557 CURVE SMOOTH",
-"436 570 OFFCURVE",
-"441 583 OFFCURVE",
-"441 594 CURVE SMOOTH",
-"441 623 OFFCURVE",
-"407 643 OFFCURVE",
-"365 643 CURVE SMOOTH",
-"354 643 OFFCURVE",
-"343 642 OFFCURVE",
-"332 639 CURVE SMOOTH",
-"244 619 OFFCURVE",
-"128 538 OFFCURVE",
-"128 451 CURVE SMOOTH",
-"128 434 OFFCURVE",
-"131 416 OFFCURVE",
-"137 398 CURVE",
-"83 341 OFFCURVE",
-"47 272 OFFCURVE",
-"47 176 CURVE SMOOTH",
-"47 134 OFFCURVE",
-"64 76 OFFCURVE",
-"92 49 CURVE SMOOTH",
-"178 -34 OFFCURVE",
-"252 -33 OFFCURVE",
-"374 -33 CURVE SMOOTH",
-"415 -33 OFFCURVE",
-"472 -12 OFFCURVE",
-"521 21 CURVE",
-"550 11 OFFCURVE",
-"579 4 OFFCURVE",
-"606 4 CURVE SMOOTH",
-"621 4 OFFCURVE",
-"635 6 OFFCURVE",
-"649 10 CURVE SMOOTH",
-"678 18 OFFCURVE",
-"687 30 OFFCURVE",
-"687 39 CURVE SMOOTH",
-"687 49 OFFCURVE",
-"674 56 OFFCURVE",
-"665 51 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"377 569 OFFCURVE",
-"306 524 OFFCURVE",
-"286 512 CURVE SMOOTH",
-"252 491 OFFCURVE",
-"219 469 OFFCURVE",
-"189 445 CURVE",
-"189 447 OFFCURVE",
-"189 450 OFFCURVE",
-"189 452 CURVE SMOOTH",
-"189 529 OFFCURVE",
-"316 598 OFFCURVE",
-"373 598 CURVE SMOOTH",
-"381 598 OFFCURVE",
-"387 597 OFFCURVE",
-"392 594 CURVE"
-);
-},
-{
-closed = 1;
-nodes = (
-"595 133 OFFCURVE",
-"560 88 OFFCURVE",
-"516 54 CURVE",
-"476 76 OFFCURVE",
-"439 111 OFFCURVE",
-"403 142 CURVE SMOOTH",
-"360 180 OFFCURVE",
-"324 205 OFFCURVE",
-"290 234 CURVE SMOOTH",
-"278 244 OFFCURVE",
-"267 256 OFFCURVE",
-"257 270 CURVE",
-"288 320 OFFCURVE",
-"347 355 OFFCURVE",
-"403 355 CURVE SMOOTH",
-"508 355 OFFCURVE",
-"595 283 OFFCURVE",
-"595 177 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"449 12 OFFCURVE",
-"407 -3 OFFCURVE",
-"374 -3 CURVE SMOOTH",
-"281 -3 OFFCURVE",
-"202 18 OFFCURVE",
-"144 77 CURVE SMOOTH",
-"122 98 OFFCURVE",
-"120 127 OFFCURVE",
-"120 159 CURVE SMOOTH",
-"120 170 OFFCURVE",
-"120 181 OFFCURVE",
-"120 193 CURVE SMOOTH",
-"120 265 OFFCURVE",
-"124 316 OFFCURVE",
-"152 361 CURVE",
-"170 326 OFFCURVE",
-"194 292 OFFCURVE",
-"219 263 CURVE",
-"209 241 OFFCURVE",
-"203 216 OFFCURVE",
-"203 191 CURVE SMOOTH",
-"203 148 OFFCURVE",
-"230 72 OFFCURVE",
-"290 72 CURVE SMOOTH",
-"300 72 OFFCURVE",
-"304 77 OFFCURVE",
-"304 81 CURVE SMOOTH",
-"304 86 OFFCURVE",
-"298 92 OFFCURVE",
-"288 92 CURVE SMOOTH",
-"256 92 OFFCURVE",
-"233 148 OFFCURVE",
-"233 191 CURVE SMOOTH",
-"233 207 OFFCURVE",
-"236 223 OFFCURVE",
-"242 238 CURVE",
-"251 228 OFFCURVE",
-"261 219 OFFCURVE",
-"270 212 CURVE SMOOTH",
-"304 183 OFFCURVE",
-"322 154 OFFCURVE",
-"365 116 CURVE SMOOTH",
-"400 85 OFFCURVE",
-"443 56 OFFCURVE",
-"487 35 CURVE"
-);
+width = 0;
 }
 );
-width = 695;
-}
-);
-note = ampersand;
-unicode = 0026;
-},
-{
-glyphname = paragraph;
-lastChange = "2022-02-10 14:32:54 +0000";
-layers = (
-{
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"349 617 OFFCURVE",
-"301 627 OFFCURVE",
-"257 627 CURVE SMOOTH",
-"162 627 OFFCURVE",
-"10 573 OFFCURVE",
-"10 458 CURVE SMOOTH",
-"10 387 OFFCURVE",
-"78 312 OFFCURVE",
-"133 275 CURVE SMOOTH",
-"154 260 OFFCURVE",
-"184 245 OFFCURVE",
-"210 245 CURVE SMOOTH",
-"218 245 OFFCURVE",
-"233 246 OFFCURVE",
-"233 253 CURVE SMOOTH",
-"233 262 OFFCURVE",
-"214 272 OFFCURVE",
-"208 276 CURVE SMOOTH",
-"153 309 OFFCURVE",
-"45 372 OFFCURVE",
-"45 448 CURVE SMOOTH",
-"45 546 OFFCURVE",
-"221 585 OFFCURVE",
-"296 585 CURVE SMOOTH",
-"314 585 OFFCURVE",
-"333 583 OFFCURVE",
-"350 578 CURVE",
-"382 526 OFFCURVE",
-"387 443 OFFCURVE",
-"387 383 CURVE SMOOTH",
-"387 236 OFFCURVE",
-"358 91 OFFCURVE",
-"343 -55 CURVE",
-"342 -58 OFFCURVE",
-"342 -61 OFFCURVE",
-"342 -64 CURVE SMOOTH",
-"342 -71 OFFCURVE",
-"344 -85 OFFCURVE",
-"354 -85 CURVE SMOOTH",
-"369 -85 OFFCURVE",
-"376 -68 OFFCURVE",
-"378 -57 CURVE SMOOTH",
-"381 -46 OFFCURVE",
-"382 -32 OFFCURVE",
-"384 -20 CURVE SMOOTH",
-"388 11 OFFCURVE",
-"393 42 OFFCURVE",
-"397 73 CURVE SMOOTH",
-"411 175 OFFCURVE",
-"422 277 OFFCURVE",
-"422 380 CURVE SMOOTH",
-"422 443 OFFCURVE",
-"418 534 OFFCURVE",
-"385 590 CURVE"
-);
-},
-{
-closed = 1;
-nodes = (
-"340 526 OFFCURVE",
-"337 539 OFFCURVE",
-"307 539 CURVE SMOOTH",
-"301 539 OFFCURVE",
-"292 538 OFFCURVE",
-"292 529 CURVE SMOOTH",
-"292 520 OFFCURVE",
-"294 510 OFFCURVE",
-"294 501 CURVE SMOOTH",
-"296 476 OFFCURVE",
-"296 452 OFFCURVE",
-"296 428 CURVE SMOOTH",
-"296 277 OFFCURVE",
-"282 -56 OFFCURVE",
-"226 -190 CURVE SMOOTH",
-"224 -196 OFFCURVE",
-"221 -201 OFFCURVE",
-"221 -208 CURVE SMOOTH",
-"221 -213 OFFCURVE",
-"224 -216 OFFCURVE",
-"230 -216 CURVE SMOOTH",
-"244 -216 OFFCURVE",
-"265 -199 OFFCURVE",
-"270 -186 CURVE SMOOTH",
-"281 -159 OFFCURVE",
-"286 -126 OFFCURVE",
-"292 -98 CURVE SMOOTH",
-"310 -5 OFFCURVE",
-"320 89 OFFCURVE",
-"327 183 CURVE SMOOTH",
-"335 291 OFFCURVE",
-"340 400 OFFCURVE",
-"340 508 CURVE SMOOTH"
-);
-}
-);
-width = 498;
-}
-);
-note = paragraph;
-unicode = 00B6;
-},
-{
-glyphname = section;
-lastChange = "2022-02-10 14:33:01 +0000";
-layers = (
-{
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"537 115 OFFCURVE",
-"532 142 OFFCURVE",
-"522 165 CURVE SMOOTH",
-"439 338 OFFCURVE",
-"130 300 OFFCURVE",
-"130 401 CURVE SMOOTH",
-"130 458 OFFCURVE",
-"233 490 OFFCURVE",
-"277 499 CURVE SMOOTH",
-"302 505 OFFCURVE",
-"328 508 OFFCURVE",
-"355 508 CURVE SMOOTH",
-"376 508 OFFCURVE",
-"399 506 OFFCURVE",
-"419 498 CURVE",
-"429 468 OFFCURVE",
-"450 405 OFFCURVE",
-"489 405 CURVE SMOOTH",
-"506 405 OFFCURVE",
-"516 417 OFFCURVE",
-"516 434 CURVE SMOOTH",
-"516 478 OFFCURVE",
-"463 515 OFFCURVE",
-"429 535 CURVE",
-"423 549 OFFCURVE",
-"421 568 OFFCURVE",
-"421 583 CURVE SMOOTH",
-"421 593 OFFCURVE",
-"424 603 OFFCURVE",
-"424 612 CURVE SMOOTH",
-"424 614 OFFCURVE",
-"423 616 OFFCURVE",
-"421 616 CURVE SMOOTH",
-"410 616 OFFCURVE",
-"408 582 OFFCURVE",
-"408 575 CURVE SMOOTH",
-"408 564 OFFCURVE",
-"409 552 OFFCURVE",
-"412 541 CURVE",
-"386 548 OFFCURVE",
-"360 551 OFFCURVE",
-"334 551 CURVE SMOOTH",
-"278 551 OFFCURVE",
-"216 537 OFFCURVE",
-"168 509 CURVE SMOOTH",
-"129 486 OFFCURVE",
-"81 449 OFFCURVE",
-"81 400 CURVE SMOOTH",
-"81 377 OFFCURVE",
-"92 356 OFFCURVE",
-"109 340 CURVE",
-"67 319 OFFCURVE",
-"42 290 OFFCURVE",
-"42 242 CURVE SMOOTH",
-"42 100 OFFCURVE",
-"437 121 OFFCURVE",
-"437 -31 CURVE SMOOTH",
-"437 -139 OFFCURVE",
-"232 -229 OFFCURVE",
-"140 -229 CURVE SMOOTH",
-"98 -229 OFFCURVE",
-"61 -215 OFFCURVE",
-"61 -167 CURVE SMOOTH",
-"61 -94 OFFCURVE",
-"130 -4 OFFCURVE",
-"207 -4 CURVE SMOOTH",
-"224 -4 OFFCURVE",
-"248 -10 OFFCURVE",
-"248 -31 CURVE SMOOTH",
-"248 -60 OFFCURVE",
-"188 -101 OFFCURVE",
-"162 -101 CURVE SMOOTH",
-"156 -101 OFFCURVE",
-"152 -99 OFFCURVE",
-"148 -94 CURVE SMOOTH",
-"147 -93 OFFCURVE",
-"143 -83 OFFCURVE",
-"142 -83 CURVE SMOOTH",
-"138 -83 OFFCURVE",
-"136 -93 OFFCURVE",
-"136 -96 CURVE SMOOTH",
-"136 -113 OFFCURVE",
-"151 -120 OFFCURVE",
-"166 -120 CURVE SMOOTH",
-"201 -120 OFFCURVE",
-"270 -89 OFFCURVE",
-"270 -47 CURVE SMOOTH",
-"270 -7 OFFCURVE",
-"212 16 OFFCURVE",
-"179 16 CURVE SMOOTH",
-"161 16 OFFCURVE",
-"142 12 OFFCURVE",
-"126 4 CURVE SMOOTH",
-"80 -17 OFFCURVE",
-"31 -92 OFFCURVE",
-"31 -142 CURVE SMOOTH",
-"31 -216 OFFCURVE",
-"78 -256 OFFCURVE",
-"150 -256 CURVE SMOOTH",
-"264 -256 OFFCURVE",
-"407 -196 OFFCURVE",
-"455 -85 CURVE",
-"468 -83 OFFCURVE",
-"476 -68 OFFCURVE",
-"483 -59 CURVE SMOOTH",
-"514 -15 OFFCURVE",
-"537 36 OFFCURVE",
-"537 90 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"504 37 OFFCURVE",
-"488 0 OFFCURVE",
-"467 -28 CURVE",
-"469 166 OFFCURVE",
-"91 160 OFFCURVE",
-"71 248 CURVE",
-"71 252 OFFCURVE",
-"70 256 OFFCURVE",
-"70 260 CURVE SMOOTH",
-"70 301 OFFCURVE",
-"114 302 OFFCURVE",
-"136 318 CURVE",
-"154 306 OFFCURVE",
-"175 296 OFFCURVE",
-"196 290 CURVE SMOOTH",
-"296 265 OFFCURVE",
-"504 207 OFFCURVE",
-"504 72 CURVE SMOOTH"
-);
-}
-);
-width = 586;
-}
-);
-note = section;
-unicode = 00A7;
-},
-{
-glyphname = copyright;
-lastChange = "2022-02-10 14:33:05 +0000";
-layers = (
-{
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"202 283 OFFCURVE",
-"240 292 OFFCURVE",
-"260 318 CURVE SMOOTH",
-"274 336 OFFCURVE",
-"283 357 OFFCURVE",
-"283 380 CURVE SMOOTH",
-"283 419 OFFCURVE",
-"257 454 OFFCURVE",
-"227 477 CURVE",
-"230 478 OFFCURVE",
-"235 481 OFFCURVE",
-"235 485 CURVE SMOOTH",
-"235 493 OFFCURVE",
-"217 495 OFFCURVE",
-"211 495 CURVE SMOOTH",
-"208 495 OFFCURVE",
-"204 495 OFFCURVE",
-"200 494 CURVE",
-"192 498 OFFCURVE",
-"182 500 OFFCURVE",
-"173 500 CURVE SMOOTH",
-"146 500 OFFCURVE",
-"94 484 OFFCURVE",
-"90 452 CURVE",
-"68 432 OFFCURVE",
-"55 404 OFFCURVE",
-"55 375 CURVE SMOOTH",
-"55 309 OFFCURVE",
-"112 283 OFFCURVE",
-"170 283 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"273 324 OFFCURVE",
-"217 297 OFFCURVE",
-"164 297 CURVE SMOOTH",
-"118 297 OFFCURVE",
-"75 321 OFFCURVE",
-"75 372 CURVE SMOOTH",
-"75 436 OFFCURVE",
-"148 472 OFFCURVE",
-"202 481 CURVE",
-"237 470 OFFCURVE",
-"273 421 OFFCURVE",
-"273 385 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"233 351 OFFCURVE",
-"236 357 OFFCURVE",
-"236 360 CURVE SMOOTH",
-"236 362 OFFCURVE",
-"235 363 OFFCURVE",
-"234 363 CURVE SMOOTH",
-"234 363 OFFCURVE",
-"233 362 OFFCURVE",
-"231 361 CURVE",
-"217 342 OFFCURVE",
-"195 332 OFFCURVE",
-"175 332 CURVE SMOOTH",
-"149 332 OFFCURVE",
-"142 351 OFFCURVE",
-"142 368 CURVE SMOOTH",
-"142 403 OFFCURVE",
-"165 453 OFFCURVE",
-"193 442 CURVE SMOOTH",
-"198 440 OFFCURVE",
-"200 436 OFFCURVE",
-"200 432 CURVE SMOOTH",
-"200 430 OFFCURVE",
-"199 428 OFFCURVE",
-"199 425 CURVE",
-"199 418 OFFCURVE",
-"190 408 OFFCURVE",
-"187 394 CURVE",
-"184 387 OFFCURVE",
-"191 387 OFFCURVE",
-"196 392 CURVE",
-"202 406 OFFCURVE",
-"211 423 OFFCURVE",
-"212 433 CURVE SMOOTH",
-"214 440 OFFCURVE",
-"214 451 OFFCURVE",
-"209 455 CURVE SMOOTH",
-"205 459 OFFCURVE",
-"198 461 OFFCURVE",
-"191 461 CURVE SMOOTH",
-"188 461 OFFCURVE",
-"185 461 OFFCURVE",
-"182 459 CURVE SMOOTH",
-"140 441 OFFCURVE",
-"119 399 OFFCURVE",
-"119 371 CURVE SMOOTH",
-"119 326 OFFCURVE",
-"142 315 OFFCURVE",
-"167 315 CURVE SMOOTH",
-"191 315 OFFCURVE",
-"217 330 OFFCURVE",
-"232 350 CURVE SMOOTH"
-);
-}
-);
-width = 281;
-}
-);
-note = copyright;
-unicode = 00A9;
-},
-{
-glyphname = registered;
-lastChange = "2022-02-10 14:33:07 +0000";
-layers = (
-{
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"202 283 OFFCURVE",
-"240 292 OFFCURVE",
-"260 318 CURVE SMOOTH",
-"274 336 OFFCURVE",
-"283 357 OFFCURVE",
-"283 380 CURVE SMOOTH",
-"283 419 OFFCURVE",
-"257 454 OFFCURVE",
-"227 477 CURVE",
-"230 478 OFFCURVE",
-"235 481 OFFCURVE",
-"235 485 CURVE SMOOTH",
-"235 493 OFFCURVE",
-"217 495 OFFCURVE",
-"211 495 CURVE SMOOTH",
-"208 495 OFFCURVE",
-"204 495 OFFCURVE",
-"200 494 CURVE",
-"192 498 OFFCURVE",
-"182 500 OFFCURVE",
-"173 500 CURVE SMOOTH",
-"146 500 OFFCURVE",
-"94 484 OFFCURVE",
-"90 452 CURVE",
-"68 432 OFFCURVE",
-"55 404 OFFCURVE",
-"55 375 CURVE SMOOTH",
-"55 309 OFFCURVE",
-"112 283 OFFCURVE",
-"170 283 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"273 324 OFFCURVE",
-"217 297 OFFCURVE",
-"164 297 CURVE SMOOTH",
-"118 297 OFFCURVE",
-"75 321 OFFCURVE",
-"75 372 CURVE SMOOTH",
-"75 436 OFFCURVE",
-"148 472 OFFCURVE",
-"202 481 CURVE",
-"237 470 OFFCURVE",
-"273 421 OFFCURVE",
-"273 385 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"229 442 OFFCURVE",
-"210 446 OFFCURVE",
-"198 446 CURVE SMOOTH",
-"162 446 LINE SMOOTH",
-"154 446 OFFCURVE",
-"130 445 OFFCURVE",
-"129 433 CURVE SMOOTH",
-"127 404 OFFCURVE",
-"126 366 OFFCURVE",
-"126 336 CURVE SMOOTH",
-"126 331 OFFCURVE",
-"129 327 OFFCURVE",
-"134 327 CURVE SMOOTH",
-"139 327 OFFCURVE",
-"149 333 OFFCURVE",
-"149 338 CURVE SMOOTH",
-"149 344 OFFCURVE",
-"147 352 OFFCURVE",
-"146 359 CURVE SMOOTH",
-"144 376 OFFCURVE",
-"142 394 OFFCURVE",
-"142 411 CURVE SMOOTH",
-"142 415 OFFCURVE",
-"142 420 OFFCURVE",
-"142 424 CURVE",
-"153 426 OFFCURVE",
-"165 427 OFFCURVE",
-"176 427 CURVE SMOOTH",
-"182 427 OFFCURVE",
-"201 427 OFFCURVE",
-"201 418 CURVE SMOOTH",
-"201 401 OFFCURVE",
-"149 394 OFFCURVE",
-"149 381 CURVE",
-"148 380 OFFCURVE",
-"148 378 OFFCURVE",
-"148 377 CURVE SMOOTH",
-"148 366 OFFCURVE",
-"210 338 OFFCURVE",
-"219 338 CURVE SMOOTH",
-"221 338 OFFCURVE",
-"226 338 OFFCURVE",
-"226 341 CURVE SMOOTH",
-"226 344 OFFCURVE",
-"222 346 OFFCURVE",
-"220 347 CURVE SMOOTH",
-"202 357 OFFCURVE",
-"185 367 OFFCURVE",
-"169 379 CURVE",
-"170 379 LINE",
-"188 388 OFFCURVE",
-"229 403 OFFCURVE",
-"229 427 CURVE SMOOTH"
-);
-}
-);
-width = 281;
-}
-);
-note = registered;
-unicode = 00AE;
-},
-{
-glyphname = trademark;
-lastChange = "2022-02-10 14:33:10 +0000";
-layers = (
-{
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"454 322 OFFCURVE",
-"451 328 OFFCURVE",
-"448 333 CURVE SMOOTH",
-"444 340 LINE SMOOTH",
-"422 381 OFFCURVE",
-"405 461 OFFCURVE",
-"405 507 CURVE SMOOTH",
-"405 511 OFFCURVE",
-"402 514 OFFCURVE",
-"396 514 CURVE SMOOTH",
-"390 514 OFFCURVE",
-"386 512 OFFCURVE",
-"384 508 CURVE",
-"384 505 OFFCURVE",
-"383 502 OFFCURVE",
-"383 500 CURVE SMOOTH",
-"383 498 OFFCURVE",
-"383 495 OFFCURVE",
-"382 493 CURVE SMOOTH",
-"381 489 OFFCURVE",
-"381 485 OFFCURVE",
-"380 481 CURVE SMOOTH",
-"379 478 OFFCURVE",
-"378 475 OFFCURVE",
-"378 471 CURVE",
-"366 432 OFFCURVE",
-"339 367 OFFCURVE",
-"307 339 CURVE",
-"277 374 OFFCURVE",
-"264 461 OFFCURVE",
-"264 507 CURVE SMOOTH",
-"264 511 OFFCURVE",
-"261 514 OFFCURVE",
-"255 514 CURVE SMOOTH",
-"248 514 OFFCURVE",
-"244 511 OFFCURVE",
-"243 507 CURVE SMOOTH",
-"243 503 OFFCURVE",
-"243 499 OFFCURVE",
-"242 497 CURVE SMOOTH",
-"241 494 OFFCURVE",
-"241 491 OFFCURVE",
-"240 488 CURVE SMOOTH",
-"239 483 OFFCURVE",
-"238 479 OFFCURVE",
-"236 474 CURVE SMOOTH",
-"222 430 OFFCURVE",
-"188 357 OFFCURVE",
-"147 336 CURVE",
-"146 335 LINE SMOOTH",
-"145 334 OFFCURVE",
-"144 333 OFFCURVE",
-"144 331 CURVE SMOOTH",
-"144 325 OFFCURVE",
-"156 312 OFFCURVE",
-"163 312 CURVE SMOOTH",
-"164 312 OFFCURVE",
-"165 312 OFFCURVE",
-"165 313 CURVE",
-"200 329 OFFCURVE",
-"230 404 OFFCURVE",
-"244 442 CURVE",
-"252 409 OFFCURVE",
-"280 312 OFFCURVE",
-"303 312 CURVE SMOOTH",
-"306 312 LINE",
-"340 329 OFFCURVE",
-"377 403 OFFCURVE",
-"392 441 CURVE",
-"394 426 OFFCURVE",
-"398 410 OFFCURVE",
-"401 394 CURVE SMOOTH",
-"405 370 OFFCURVE",
-"423 319 OFFCURVE",
-"443 303 CURVE",
-"445 300 OFFCURVE",
-"450 297 OFFCURVE",
-"454 297 CURVE SMOOTH",
-"460 297 OFFCURVE",
-"464 301 OFFCURVE",
-"464 307 CURVE SMOOTH",
-"464 311 OFFCURVE",
-"462 314 OFFCURVE",
-"458 317 CURVE"
-);
-},
-{
-closed = 1;
-nodes = (
-"124 368 OFFCURVE",
-"123 393 OFFCURVE",
-"123 419 CURVE SMOOTH",
-"123 439 OFFCURVE",
-"124 458 OFFCURVE",
-"125 478 CURVE",
-"142 479 OFFCURVE",
-"200 483 OFFCURVE",
-"209 487 CURVE SMOOTH",
-"213 488 OFFCURVE",
-"216 492 OFFCURVE",
-"216 498 CURVE SMOOTH",
-"216 505 OFFCURVE",
-"211 512 OFFCURVE",
-"205 512 CURVE SMOOTH",
-"203 512 LINE",
-"190 509 OFFCURVE",
-"174 508 OFFCURVE",
-"159 507 CURVE SMOOTH",
-"147 506 OFFCURVE",
-"136 506 OFFCURVE",
-"126 504 CURVE",
-"124 509 OFFCURVE",
-"121 511 OFFCURVE",
-"118 511 CURVE SMOOTH",
-"112 511 OFFCURVE",
-"108 506 OFFCURVE",
-"105 503 CURVE",
-"101 503 LINE SMOOTH",
-"76 503 OFFCURVE",
-"50 503 OFFCURVE",
-"25 507 CURVE SMOOTH",
-"23 507 LINE SMOOTH",
-"17 507 OFFCURVE",
-"13 501 OFFCURVE",
-"13 493 CURVE SMOOTH",
-"13 487 OFFCURVE",
-"15 484 OFFCURVE",
-"20 481 CURVE",
-"33 477 OFFCURVE",
-"83 476 OFFCURVE",
-"98 476 CURVE SMOOTH",
-"104 476 LINE",
-"104 450 LINE",
-"104 374 LINE SMOOTH",
-"103 348 OFFCURVE",
-"103 322 OFFCURVE",
-"103 296 CURVE SMOOTH",
-"103 285 OFFCURVE",
-"106 279 OFFCURVE",
-"113 279 CURVE SMOOTH",
-"123 279 OFFCURVE",
-"133 289 OFFCURVE",
-"133 299 CURVE SMOOTH",
-"133 307 OFFCURVE",
-"132 316 OFFCURVE",
-"130 325 CURVE SMOOTH",
-"129 331 OFFCURVE",
-"128 337 OFFCURVE",
-"128 343 CURVE"
-);
-}
-);
-width = 517;
-}
-);
-note = trademark;
-unicode = 2122;
-},
-{
-glyphname = degree;
-lastChange = "2022-02-10 16:03:22 +0000";
-layers = (
-{
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"239 572 OFFCURVE",
-"194 537 OFFCURVE",
-"171 537 CURVE SMOOTH",
-"148 537 OFFCURVE",
-"133 561 OFFCURVE",
-"133 582 CURVE SMOOTH",
-"133 615 OFFCURVE",
-"157 641 OFFCURVE",
-"191 641 CURVE SMOOTH",
-"217 641 OFFCURVE",
-"239 624 OFFCURVE",
-"239 596 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"267 640 OFFCURVE",
-"235 669 OFFCURVE",
-"192 669 CURVE SMOOTH",
-"142 669 OFFCURVE",
-"106 632 OFFCURVE",
-"106 582 CURVE SMOOTH",
-"106 545 OFFCURVE",
-"132 509 OFFCURVE",
-"171 509 CURVE SMOOTH",
-"209 509 OFFCURVE",
-"267 556 OFFCURVE",
-"267 596 CURVE SMOOTH"
-);
-}
-);
-width = 338;
-}
-);
-note = degree;
-unicode = 00B0;
-},
-{
-glyphname = minute;
-lastChange = "2022-02-10 14:33:20 +0000";
-layers = (
-{
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"81 457 OFFCURVE",
-"87 468 OFFCURVE",
-"97 490 CURVE SMOOTH",
-"117 529 OFFCURVE",
-"132 567 OFFCURVE",
-"141 612 CURVE SMOOTH",
-"142 615 OFFCURVE",
-"143 619 OFFCURVE",
-"143 622 CURVE SMOOTH",
-"143 626 OFFCURVE",
-"142 630 OFFCURVE",
-"139 632 CURVE SMOOTH",
-"133 637 OFFCURVE",
-"121 640 OFFCURVE",
-"111 640 CURVE SMOOTH",
-"107 640 OFFCURVE",
-"104 639 OFFCURVE",
-"103 635 CURVE SMOOTH",
-"92 584 OFFCURVE",
-"74 525 OFFCURVE",
-"56 474 CURVE SMOOTH",
-"53 466 OFFCURVE",
-"55 459 OFFCURVE",
-"61 454 CURVE SMOOTH",
-"63 452 OFFCURVE",
-"66 450 OFFCURVE",
-"69 450 CURVE SMOOTH",
-"71 450 OFFCURVE",
-"73 451 OFFCURVE",
-"75 453 CURVE"
-);
-}
-);
-width = 158;
-}
-);
-leftKerningGroup = quotes;
-rightKerningGroup = quotes;
-unicode = 2032;
-},
-{
-glyphname = second;
-lastChange = "2022-02-10 14:33:22 +0000";
-layers = (
-{
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"205 457 OFFCURVE",
-"211 468 OFFCURVE",
-"221 490 CURVE SMOOTH",
-"241 529 OFFCURVE",
-"256 567 OFFCURVE",
-"265 612 CURVE SMOOTH",
-"266 615 OFFCURVE",
-"267 619 OFFCURVE",
-"267 622 CURVE SMOOTH",
-"267 626 OFFCURVE",
-"266 630 OFFCURVE",
-"263 632 CURVE SMOOTH",
-"257 637 OFFCURVE",
-"245 640 OFFCURVE",
-"235 640 CURVE SMOOTH",
-"231 640 OFFCURVE",
-"228 639 OFFCURVE",
-"227 635 CURVE SMOOTH",
-"216 584 OFFCURVE",
-"198 525 OFFCURVE",
-"180 474 CURVE SMOOTH",
-"177 466 OFFCURVE",
-"179 459 OFFCURVE",
-"185 454 CURVE SMOOTH",
-"187 452 OFFCURVE",
-"190 450 OFFCURVE",
-"193 450 CURVE SMOOTH",
-"195 450 OFFCURVE",
-"197 451 OFFCURVE",
-"199 453 CURVE"
-);
-},
-{
-closed = 1;
-nodes = (
-"81 457 OFFCURVE",
-"87 468 OFFCURVE",
-"97 490 CURVE SMOOTH",
-"117 529 OFFCURVE",
-"132 567 OFFCURVE",
-"141 612 CURVE SMOOTH",
-"142 615 OFFCURVE",
-"143 619 OFFCURVE",
-"143 622 CURVE SMOOTH",
-"143 626 OFFCURVE",
-"142 630 OFFCURVE",
-"139 632 CURVE SMOOTH",
-"133 637 OFFCURVE",
-"121 640 OFFCURVE",
-"111 640 CURVE SMOOTH",
-"107 640 OFFCURVE",
-"104 639 OFFCURVE",
-"103 635 CURVE SMOOTH",
-"92 584 OFFCURVE",
-"74 525 OFFCURVE",
-"56 474 CURVE SMOOTH",
-"53 466 OFFCURVE",
-"55 459 OFFCURVE",
-"61 454 CURVE SMOOTH",
-"63 452 OFFCURVE",
-"66 450 OFFCURVE",
-"69 450 CURVE SMOOTH",
-"71 450 OFFCURVE",
-"73 451 OFFCURVE",
-"75 453 CURVE"
-);
-}
-);
-width = 282;
-}
-);
-leftKerningGroup = quotes;
-rightKerningGroup = quotes;
-unicode = 2033;
-},
-{
-glyphname = bar;
-lastChange = "2022-02-10 14:33:27 +0000";
-layers = (
-{
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"181 377 OFFCURVE",
-"184 508 OFFCURVE",
-"220 601 CURVE",
-"220 602 OFFCURVE",
-"221 603 OFFCURVE",
-"221 604 CURVE SMOOTH",
-"221 615 OFFCURVE",
-"201 617 OFFCURVE",
-"195 617 CURVE SMOOTH",
-"185 617 OFFCURVE",
-"180 615 OFFCURVE",
-"172 609 CURVE SMOOTH",
-"169 606 OFFCURVE",
-"164 604 OFFCURVE",
-"161 600 CURVE SMOOTH",
-"152 587 OFFCURVE",
-"151 554 OFFCURVE",
-"151 534 CURVE SMOOTH",
-"151 474 OFFCURVE",
-"153 415 OFFCURVE",
-"153 356 CURVE SMOOTH",
-"153 209 OFFCURVE",
-"150 62 OFFCURVE",
-"150 -84 CURVE SMOOTH",
-"150 -96 OFFCURVE",
-"153 -113 OFFCURVE",
-"168 -113 CURVE SMOOTH",
-"183 -113 OFFCURVE",
-"199 -96 OFFCURVE",
-"199 -80 CURVE SMOOTH",
-"199 -69 OFFCURVE",
-"197 -58 OFFCURVE",
-"196 -47 CURVE SMOOTH",
-"194 -20 OFFCURVE",
-"192 8 OFFCURVE",
-"190 35 CURVE SMOOTH",
-"185 116 OFFCURVE",
-"181 197 OFFCURVE",
-"181 278 CURVE SMOOTH"
-);
-}
-);
-width = 310;
-}
-);
-note = bar;
-unicode = 007C;
-},
-{
-glyphname = brokenbar;
-lastChange = "2022-02-10 14:33:35 +0000";
-layers = (
-{
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"181 330 LINE",
-"183 420 OFFCURVE",
-"190 524 OFFCURVE",
-"220 601 CURVE",
-"220 602 OFFCURVE",
-"221 603 OFFCURVE",
-"221 604 CURVE SMOOTH",
-"221 615 OFFCURVE",
-"201 617 OFFCURVE",
-"195 617 CURVE SMOOTH",
-"185 617 OFFCURVE",
-"180 615 OFFCURVE",
-"172 609 CURVE SMOOTH",
-"169 606 OFFCURVE",
-"164 604 OFFCURVE",
-"161 600 CURVE SMOOTH",
-"152 587 OFFCURVE",
-"151 554 OFFCURVE",
-"151 534 CURVE SMOOTH",
-"151 474 OFFCURVE",
-"153 415 OFFCURVE",
-"153 356 CURVE SMOOTH",
-"153 334 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"152 222 LINE",
-"151 120 OFFCURVE",
-"150 18 OFFCURVE",
-"150 -84 CURVE SMOOTH",
-"150 -96 OFFCURVE",
-"153 -113 OFFCURVE",
-"168 -113 CURVE SMOOTH",
-"183 -113 OFFCURVE",
-"199 -96 OFFCURVE",
-"199 -80 CURVE SMOOTH",
-"199 -69 OFFCURVE",
-"197 -58 OFFCURVE",
-"196 -47 CURVE SMOOTH",
-"190 35 LINE SMOOTH",
-"186 98 OFFCURVE",
-"183 160 OFFCURVE",
-"182 223 CURVE"
-);
-}
-);
-width = 310;
-}
-);
-note = brokenbar;
-unicode = 00A6;
-},
-{
-glyphname = dagger;
-lastChange = "2022-02-07 15:17:40 +0000";
-layers = (
-{
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"190 411 OFFCURVE",
-"236 418 OFFCURVE",
-"257 428 CURVE",
-"266 431 OFFCURVE",
-"269 437 OFFCURVE",
-"269 446 CURVE SMOOTH",
-"269 455 OFFCURVE",
-"263 468 OFFCURVE",
-"252 468 CURVE SMOOTH",
-"251 468 OFFCURVE",
-"250 468 OFFCURVE",
-"249 468 CURVE",
-"222 460 OFFCURVE",
-"196 454 OFFCURVE",
-"169 450 CURVE",
-"173 502 OFFCURVE",
-"181 552 OFFCURVE",
-"200 601 CURVE",
-"200 602 OFFCURVE",
-"201 603 OFFCURVE",
-"201 604 CURVE SMOOTH",
-"201 614 OFFCURVE",
-"182 617 OFFCURVE",
-"175 617 CURVE SMOOTH",
-"166 617 OFFCURVE",
-"159 615 OFFCURVE",
-"152 609 CURVE SMOOTH",
-"149 606 OFFCURVE",
-"145 604 OFFCURVE",
-"142 601 CURVE SMOOTH",
-"132 589 OFFCURVE",
-"131 553 OFFCURVE",
-"131 533 CURVE SMOOTH",
-"131 505 OFFCURVE",
-"132 476 OFFCURVE",
-"133 448 CURVE",
-"120 447 LINE SMOOTH",
-"95 447 OFFCURVE",
-"73 451 OFFCURVE",
-"48 455 CURVE SMOOTH",
-"47 455 OFFCURVE",
-"46 455 OFFCURVE",
-"45 455 CURVE SMOOTH",
-"34 455 OFFCURVE",
-"29 442 OFFCURVE",
-"29 433 CURVE SMOOTH",
-"29 424 OFFCURVE",
-"33 417 OFFCURVE",
-"42 414 CURVE SMOOTH",
-"66 407 OFFCURVE",
-"95 406 OFFCURVE",
-"120 406 CURVE SMOOTH",
-"133 406 LINE",
-"133 386 OFFCURVE",
-"133 366 OFFCURVE",
-"133 346 CURVE SMOOTH",
-"133 203 OFFCURVE",
-"130 59 OFFCURVE",
-"130 -84 CURVE SMOOTH",
-"130 -96 OFFCURVE",
-"133 -113 OFFCURVE",
-"148 -113 CURVE SMOOTH",
-"163 -113 OFFCURVE",
-"179 -96 OFFCURVE",
-"179 -80 CURVE SMOOTH",
-"179 -70 OFFCURVE",
-"177 -58 OFFCURVE",
-"176 -47 CURVE SMOOTH",
-"174 -21 OFFCURVE",
-"172 6 OFFCURVE",
-"170 33 CURVE SMOOTH",
-"165 112 OFFCURVE",
-"161 191 OFFCURVE",
-"161 270 CURVE SMOOTH",
-"161 316 OFFCURVE",
-"163 362 OFFCURVE",
-"166 408 CURVE"
-);
-}
-);
-width = 283;
-}
-);
-note = dagger;
-unicode = 2020;
-},
-{
-glyphname = daggerdbl;
-lastChange = "2022-02-07 15:17:40 +0000";
-layers = (
-{
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"195 412 OFFCURVE",
-"230 417 OFFCURVE",
-"257 428 CURVE SMOOTH",
-"266 431 OFFCURVE",
-"269 437 OFFCURVE",
-"269 446 CURVE SMOOTH",
-"269 455 OFFCURVE",
-"263 468 OFFCURVE",
-"252 468 CURVE SMOOTH",
-"251 468 OFFCURVE",
-"250 468 OFFCURVE",
-"249 468 CURVE",
-"222 460 OFFCURVE",
-"196 454 OFFCURVE",
-"169 450 CURVE",
-"173 502 OFFCURVE",
-"181 552 OFFCURVE",
-"200 601 CURVE",
-"200 602 OFFCURVE",
-"201 603 OFFCURVE",
-"201 604 CURVE SMOOTH",
-"201 614 OFFCURVE",
-"182 617 OFFCURVE",
-"175 617 CURVE SMOOTH",
-"166 617 OFFCURVE",
-"158 615 OFFCURVE",
-"152 609 CURVE SMOOTH",
-"149 605 OFFCURVE",
-"144 604 OFFCURVE",
-"141 600 CURVE SMOOTH",
-"132 587 OFFCURVE",
-"131 554 OFFCURVE",
-"131 534 CURVE SMOOTH",
-"131 506 OFFCURVE",
-"132 476 OFFCURVE",
-"133 448 CURVE",
-"120 447 LINE SMOOTH",
-"95 447 OFFCURVE",
-"73 451 OFFCURVE",
-"48 455 CURVE SMOOTH",
-"47 455 OFFCURVE",
-"46 455 OFFCURVE",
-"45 455 CURVE SMOOTH",
-"34 455 OFFCURVE",
-"29 442 OFFCURVE",
-"29 433 CURVE SMOOTH",
-"29 424 OFFCURVE",
-"33 417 OFFCURVE",
-"42 414 CURVE SMOOTH",
-"66 407 OFFCURVE",
-"95 406 OFFCURVE",
-"120 406 CURVE SMOOTH",
-"133 406 LINE",
-"133 386 OFFCURVE",
-"133 366 OFFCURVE",
-"133 346 CURVE SMOOTH",
-"133 309 OFFCURVE",
-"133 272 OFFCURVE",
-"133 235 CURVE",
-"126 235 LINE SMOOTH",
-"99 234 OFFCURVE",
-"74 240 OFFCURVE",
-"47 245 CURVE SMOOTH",
-"46 245 OFFCURVE",
-"45 245 OFFCURVE",
-"44 245 CURVE SMOOTH",
-"33 245 OFFCURVE",
-"28 232 OFFCURVE",
-"28 223 CURVE SMOOTH",
-"28 214 OFFCURVE",
-"31 207 OFFCURVE",
-"40 204 CURVE SMOOTH",
-"64 197 OFFCURVE",
-"91 195 OFFCURVE",
-"116 195 CURVE SMOOTH",
-"132 196 LINE",
-"132 102 OFFCURVE",
-"130 9 OFFCURVE",
-"130 -84 CURVE SMOOTH",
-"130 -96 OFFCURVE",
-"133 -113 OFFCURVE",
-"148 -113 CURVE SMOOTH",
-"163 -113 OFFCURVE",
-"179 -96 OFFCURVE",
-"179 -80 CURVE SMOOTH",
-"179 -55 OFFCURVE",
-"174 -17 OFFCURVE",
-"172 10 CURVE SMOOTH",
-"167 72 OFFCURVE",
-"164 135 OFFCURVE",
-"162 198 CURVE",
-"193 201 OFFCURVE",
-"227 206 OFFCURVE",
-"256 217 CURVE SMOOTH",
-"264 220 OFFCURVE",
-"267 227 OFFCURVE",
-"267 235 CURVE SMOOTH",
-"267 244 OFFCURVE",
-"262 258 OFFCURVE",
-"251 258 CURVE SMOOTH",
-"250 258 OFFCURVE",
-"248 258 OFFCURVE",
-"247 257 CURVE",
-"219 249 OFFCURVE",
-"191 241 OFFCURVE",
-"162 237 CURVE",
-"161 270 LINE SMOOTH",
-"161 316 OFFCURVE",
-"163 362 OFFCURVE",
-"166 408 CURVE"
-);
-}
-);
-width = 305;
-}
-);
-note = daggerdbl;
-unicode = 2021;
-},
-{
-color = 3;
-glyphname = numero;
-lastChange = "2022-02-08 10:23:33 +0000";
-layers = (
-{
-anchors = (
-{
-name = bottom;
-position = "{540, 0}";
-},
-{
-name = top;
-position = "{603, 565}";
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"838 28 OFFCURVE",
-"840 32 OFFCURVE",
-"840 35 CURVE SMOOTH",
-"840 43 OFFCURVE",
-"833 48 OFFCURVE",
-"823 51 CURVE",
-"807 52 OFFCURVE",
-"804 -11 OFFCURVE",
-"772 -4 CURVE SMOOTH",
-"763 -2 OFFCURVE",
-"749 -7 OFFCURVE",
-"734 -7 CURVE SMOOTH",
-"707 -7 OFFCURVE",
-"678 10 OFFCURVE",
-"678 123 CURVE SMOOTH",
-"678 192 OFFCURVE",
-"745 299 OFFCURVE",
-"745 386 CURVE SMOOTH",
-"745 399 OFFCURVE",
-"744 412 OFFCURVE",
-"740 424 CURVE SMOOTH",
-"723 484 OFFCURVE",
-"705 513 OFFCURVE",
-"672 536 CURVE SMOOTH",
-"662 542 OFFCURVE",
-"647 546 OFFCURVE",
-"630 546 CURVE SMOOTH",
-"608 546 OFFCURVE",
-"583 540 OFFCURVE",
-"564 523 CURVE",
-"542 492 OFFCURVE",
-"485 418 OFFCURVE",
-"484 365 CURVE SMOOTH",
-"484 343 OFFCURVE",
-"481 334 OFFCURVE",
-"477 334 CURVE SMOOTH",
-"472 334 OFFCURVE",
-"465 351 OFFCURVE",
-"460 372 CURVE",
-"426 465 OFFCURVE",
-"367 589 OFFCURVE",
-"241 589 CURVE SMOOTH",
-"227 589 OFFCURVE",
-"211 588 OFFCURVE",
-"195 584 CURVE SMOOTH",
-"111 567 OFFCURVE",
-"18 516 OFFCURVE",
-"18 400 CURVE SMOOTH",
-"18 371 OFFCURVE",
-"24 337 OFFCURVE",
-"38 298 CURVE SMOOTH",
-"64 228 OFFCURVE",
-"138 183 OFFCURVE",
-"199 183 CURVE SMOOTH",
-"212 183 OFFCURVE",
-"225 185 OFFCURVE",
-"236 189 CURVE SMOOTH",
-"267 200 OFFCURVE",
-"312 256 OFFCURVE",
-"312 310 CURVE SMOOTH",
-"312 351 OFFCURVE",
-"282 393 OFFCURVE",
-"256 404 CURVE SMOOTH",
-"246 409 OFFCURVE",
-"237 410 OFFCURVE",
-"231 410 CURVE SMOOTH",
-"220 410 OFFCURVE",
-"215 406 OFFCURVE",
-"215 400 CURVE SMOOTH",
-"215 395 OFFCURVE",
-"218 390 OFFCURVE",
-"225 387 CURVE SMOOTH",
-"254 372 OFFCURVE",
-"269 342 OFFCURVE",
-"269 310 CURVE SMOOTH",
-"269 272 OFFCURVE",
-"248 233 OFFCURVE",
-"205 218 CURVE SMOOTH",
-"201 216 OFFCURVE",
-"195 216 OFFCURVE",
-"189 216 CURVE SMOOTH",
-"148 216 OFFCURVE",
-"76 254 OFFCURVE",
-"58 304 CURVE SMOOTH",
-"46 337 OFFCURVE",
-"40 367 OFFCURVE",
-"40 393 CURVE SMOOTH",
-"40 496 OFFCURVE",
-"124 547 OFFCURVE",
-"203 560 CURVE SMOOTH",
-"214 562 OFFCURVE",
-"225 563 OFFCURVE",
-"235 563 CURVE SMOOTH",
-"313 563 OFFCURVE",
-"383 514 OFFCURVE",
-"407 412 CURVE SMOOTH",
-"420 354 OFFCURVE",
-"431 291 OFFCURVE",
-"431 221 CURVE SMOOTH",
-"431 153 OFFCURVE",
-"421 79 OFFCURVE",
-"393 -3 CURVE SMOOTH",
-"390 -13 OFFCURVE",
-"382 -34 OFFCURVE",
-"382 -47 CURVE SMOOTH",
-"382 -55 OFFCURVE",
-"385 -60 OFFCURVE",
-"391 -60 CURVE SMOOTH",
-"403 -60 OFFCURVE",
-"468 -47 OFFCURVE",
-"471 -18 CURVE SMOOTH",
-"475 23 OFFCURVE",
-"483 123 OFFCURVE",
-"496 235 CURVE SMOOTH",
-"513 387 OFFCURVE",
-"575 502 OFFCURVE",
-"615 507 CURVE SMOOTH",
-"657 513 OFFCURVE",
-"699 457 OFFCURVE",
-"699 396 CURVE SMOOTH",
-"699 386 OFFCURVE",
-"658 201 OFFCURVE",
-"652 92 CURVE SMOOTH",
-"648 31 OFFCURVE",
-"685 -8 OFFCURVE",
-"707 -20 CURVE SMOOTH",
-"716 -25 OFFCURVE",
-"728 -28 OFFCURVE",
-"742 -28 CURVE SMOOTH",
-"771 -28 OFFCURVE",
-"808 -14 OFFCURVE",
-"835 23 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"986 529 OFFCURVE",
-"964 558 OFFCURVE",
-"925 558 CURVE SMOOTH",
-"910 558 OFFCURVE",
-"847 542 OFFCURVE",
-"818 487 CURVE SMOOTH",
-"814 479 OFFCURVE",
-"812 472 OFFCURVE",
-"812 464 CURVE SMOOTH",
-"812 451 OFFCURVE",
-"817 439 OFFCURVE",
-"826 429 CURVE",
-"823 418 OFFCURVE",
-"822 406 OFFCURVE",
-"822 395 CURVE SMOOTH",
-"822 359 OFFCURVE",
-"842 358 OFFCURVE",
-"849 352 CURVE SMOOTH",
-"853 348 OFFCURVE",
-"863 344 OFFCURVE",
-"873 344 CURVE SMOOTH",
-"878 344 OFFCURVE",
-"882 344 OFFCURVE",
-"886 346 CURVE SMOOTH",
-"902 353 OFFCURVE",
-"942 357 OFFCURVE",
-"964 405 CURVE SMOOTH",
-"979 436 OFFCURVE",
-"986 475 OFFCURVE",
-"986 496 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"950 472 OFFCURVE",
-"935 427 OFFCURVE",
-"922 403 CURVE SMOOTH",
-"908 377 OFFCURVE",
-"885 364 OFFCURVE",
-"871 370 CURVE SMOOTH",
-"861 375 OFFCURVE",
-"839 381 OFFCURVE",
-"840 412 CURVE SMOOTH",
-"840 414 OFFCURVE",
-"840 416 OFFCURVE",
-"841 417 CURVE",
-"846 413 OFFCURVE",
-"854 412 OFFCURVE",
-"862 412 CURVE SMOOTH",
-"879 412 OFFCURVE",
-"929 419 OFFCURVE",
-"929 447 CURVE SMOOTH",
-"929 453 OFFCURVE",
-"926 461 OFFCURVE",
-"920 469 CURVE",
-"914 476 OFFCURVE",
-"908 480 OFFCURVE",
-"903 480 CURVE SMOOTH",
-"900 480 OFFCURVE",
-"896 478 OFFCURVE",
-"893 475 CURVE SMOOTH",
-"891 473 OFFCURVE",
-"888 469 OFFCURVE",
-"888 467 CURVE SMOOTH",
-"888 464 OFFCURVE",
-"890 462 OFFCURVE",
-"898 462 CURVE SMOOTH",
-"906 463 OFFCURVE",
-"917 462 OFFCURVE",
-"917 452 CURVE SMOOTH",
-"917 450 OFFCURVE",
-"916 447 OFFCURVE",
-"915 444 CURVE SMOOTH",
-"911 433 OFFCURVE",
-"897 428 OFFCURVE",
-"882 428 CURVE SMOOTH",
-"868 428 OFFCURVE",
-"854 432 OFFCURVE",
-"845 442 CURVE",
-"859 480 OFFCURVE",
-"889 499 OFFCURVE",
-"889 505 CURVE SMOOTH",
-"889 508 OFFCURVE",
-"885 510 OFFCURVE",
-"880 510 CURVE SMOOTH",
-"877 510 OFFCURVE",
-"873 509 OFFCURVE",
-"870 507 CURVE SMOOTH",
-"864 502 OFFCURVE",
-"849 486 OFFCURVE",
-"838 461 CURVE",
-"838 466 OFFCURVE",
-"838 471 OFFCURVE",
-"839 477 CURVE SMOOTH",
-"845 501 OFFCURVE",
-"879 533 OFFCURVE",
-"909 533 CURVE SMOOTH",
-"932 533 OFFCURVE",
-"950 515 OFFCURVE",
-"950 492 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"962 282 OFFCURVE",
-"947 285 OFFCURVE",
-"922 285 CURVE SMOOTH",
-"894 285 OFFCURVE",
-"863 285 OFFCURVE",
-"828 285 CURVE SMOOTH",
-"810 285 OFFCURVE",
-"784 280 OFFCURVE",
-"771 280 CURVE SMOOTH",
-"763 280 OFFCURVE",
-"760 277 OFFCURVE",
-"760 273 CURVE SMOOTH",
-"760 268 OFFCURVE",
-"765 262 OFFCURVE",
-"773 258 CURVE SMOOTH",
-"778 256 OFFCURVE",
-"786 255 OFFCURVE",
-"794 255 CURVE SMOOTH",
-"803 255 OFFCURVE",
-"814 256 OFFCURVE",
-"823 256 CURVE SMOOTH",
-"828 256 OFFCURVE",
-"832 256 OFFCURVE",
-"836 255 CURVE",
-"860 253 OFFCURVE",
-"933 252 OFFCURVE",
-"959 252 CURVE SMOOTH",
-"969 252 OFFCURVE",
-"978 260 OFFCURVE",
-"978 268 CURVE SMOOTH",
-"978 272 OFFCURVE",
-"975 276 OFFCURVE",
-"969 278 CURVE"
-);
-}
-);
-width = 1002;
-}
-);
-unicode = 2116;
+note = NULL;
 },
 {
 glyphname = cedi;
@@ -30674,6 +29067,122 @@ width = 596;
 );
 note = Euro;
 unicode = 20AC;
+},
+{
+glyphname = florin;
+lastChange = "2022-02-07 15:17:40 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"234 286 OFFCURVE",
+"241 302 OFFCURVE",
+"241 308 CURVE SMOOTH",
+"241 312 OFFCURVE",
+"239 317 OFFCURVE",
+"233 317 CURVE SMOOTH",
+"214 317 OFFCURVE",
+"196 320 OFFCURVE",
+"178 322 CURVE",
+"196 389 OFFCURVE",
+"215 451 OFFCURVE",
+"220 463 CURVE SMOOTH",
+"226 478 OFFCURVE",
+"271 592 OFFCURVE",
+"293 592 CURVE SMOOTH",
+"313 592 OFFCURVE",
+"311 578 OFFCURVE",
+"312 564 CURVE SMOOTH",
+"312 560 OFFCURVE",
+"314 556 OFFCURVE",
+"314 553 CURVE SMOOTH",
+"314 544 OFFCURVE",
+"297 512 OFFCURVE",
+"297 503 CURVE SMOOTH",
+"297 497 OFFCURVE",
+"299 488 OFFCURVE",
+"308 488 CURVE SMOOTH",
+"320 488 OFFCURVE",
+"326 505 OFFCURVE",
+"329 514 CURVE SMOOTH",
+"334 530 OFFCURVE",
+"338 528 OFFCURVE",
+"338 549 CURVE SMOOTH",
+"338 590 OFFCURVE",
+"324 611 OFFCURVE",
+"281 611 CURVE SMOOTH",
+"267 611 OFFCURVE",
+"257 605 OFFCURVE",
+"248 595 CURVE SMOOTH",
+"203 546 OFFCURVE",
+"192 494 OFFCURVE",
+"172 429 CURVE SMOOTH",
+"160 391 OFFCURVE",
+"149 357 OFFCURVE",
+"140 325 CURVE",
+"136 325 LINE SMOOTH",
+"105 325 OFFCURVE",
+"53 311 OFFCURVE",
+"53 285 CURVE SMOOTH",
+"53 283 OFFCURVE",
+"55 280 OFFCURVE",
+"60 280 CURVE SMOOTH",
+"64 280 OFFCURVE",
+"66 280 OFFCURVE",
+"69 281 CURVE SMOOTH",
+"88 288 OFFCURVE",
+"109 291 OFFCURVE",
+"131 292 CURVE",
+"119 249 OFFCURVE",
+"108 207 OFFCURVE",
+"96 158 CURVE SMOOTH",
+"86 120 OFFCURVE",
+"59 35 OFFCURVE",
+"43 -1 CURVE SMOOTH",
+"36 -15 OFFCURVE",
+"-3 -93 OFFCURVE",
+"-22 -104 CURVE SMOOTH",
+"-32 -110 OFFCURVE",
+"-40 -112 OFFCURVE",
+"-45 -112 CURVE SMOOTH",
+"-54 -112 OFFCURVE",
+"-58 -105 OFFCURVE",
+"-58 -95 CURVE SMOOTH",
+"-58 -75 OFFCURVE",
+"-42 -42 OFFCURVE",
+"-36 -37 CURVE",
+"-35 -32 OFFCURVE",
+"-37 -22 OFFCURVE",
+"-46 -22 CURVE SMOOTH",
+"-66 -22 OFFCURVE",
+"-78 -67 OFFCURVE",
+"-78 -82 CURVE SMOOTH",
+"-80 -124 OFFCURVE",
+"-66 -146 OFFCURVE",
+"-21 -146 CURVE SMOOTH",
+"-9 -146 OFFCURVE",
+"1 -140 OFFCURVE",
+"10 -131 CURVE SMOOTH",
+"57 -84 OFFCURVE",
+"119 90 OFFCURVE",
+"134 156 CURVE SMOOTH",
+"138 177 OFFCURVE",
+"153 232 OFFCURVE",
+"169 290 CURVE",
+"187 288 OFFCURVE",
+"205 286 OFFCURVE",
+"223 286 CURVE SMOOTH"
+);
+}
+);
+width = 257;
+}
+);
+note = florin;
+unicode = 0192;
 },
 {
 glyphname = franc;
@@ -36698,361 +35207,2040 @@ note = lozenge;
 unicode = 25CA;
 },
 {
-color = 1;
-glyphname = brevecomb_acutecomb;
-lastChange = "2022-02-17 10:26:18 +0000";
+glyphname = apple;
+lastChange = "2022-02-07 15:17:40 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"362 101 OFFCURVE",
+"384 124 OFFCURVE",
+"409 154 CURVE SMOOTH",
+"428 177 OFFCURVE",
+"448 207 OFFCURVE",
+"459 241 CURVE",
+"416 258 OFFCURVE",
+"387 301 OFFCURVE",
+"387 351 CURVE SMOOTH",
+"387 406 OFFCURVE",
+"418 439 OFFCURVE",
+"445 454 CURVE",
+"417 500 OFFCURVE",
+"374 510 OFFCURVE",
+"347 510 CURVE SMOOTH",
+"337 510 OFFCURVE",
+"329 509 OFFCURVE",
+"325 507 CURVE SMOOTH",
+"314 503 OFFCURVE",
+"289 495 OFFCURVE",
+"269 489 CURVE SMOOTH",
+"261 487 OFFCURVE",
+"253 485 OFFCURVE",
+"245 485 CURVE SMOOTH",
+"238 485 OFFCURVE",
+"231 486 OFFCURVE",
+"224 488 CURVE SMOOTH",
+"204 494 OFFCURVE",
+"179 503 OFFCURVE",
+"169 507 CURVE SMOOTH",
+"165 508 OFFCURVE",
+"159 509 OFFCURVE",
+"151 509 CURVE SMOOTH",
+"123 509 OFFCURVE",
+"75 497 OFFCURVE",
+"43 438 CURVE SMOOTH",
+"27 409 OFFCURVE",
+"21 375 OFFCURVE",
+"21 340 CURVE SMOOTH",
+"21 272 OFFCURVE",
+"46 200 OFFCURVE",
+"84 154 CURVE SMOOTH",
+"109 124 OFFCURVE",
+"130 101 OFFCURVE",
+"157 101 CURVE SMOOTH",
+"184 101 OFFCURVE",
+"197 110 OFFCURVE",
+"205 115 CURVE SMOOTH",
+"215 122 OFFCURVE",
+"231 125 OFFCURVE",
+"247 125 CURVE SMOOTH",
+"262 125 OFFCURVE",
+"278 122 OFFCURVE",
+"288 115 CURVE SMOOTH",
+"297 110 OFFCURVE",
+"310 101 OFFCURVE",
+"336 101 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"267 501 OFFCURVE",
+"300 506 OFFCURVE",
+"326 544 CURVE SMOOTH",
+"344 570 OFFCURVE",
+"350 598 OFFCURVE",
+"350 616 CURVE SMOOTH",
+"350 623 OFFCURVE",
+"349 629 OFFCURVE",
+"347 632 CURVE",
+"335 637 OFFCURVE",
+"293 619 OFFCURVE",
+"271 587 CURVE SMOOTH",
+"254 561 OFFCURVE",
+"248 532 OFFCURVE",
+"248 514 CURVE SMOOTH",
+"248 509 OFFCURVE",
+"248 504 OFFCURVE",
+"249 501 CURVE"
+);
+}
+);
+width = 478;
+}
+);
+note = apple;
+unicode = F8FF;
+},
+{
+glyphname = at;
+lastChange = "2022-02-10 16:18:31 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"498 260 OFFCURVE",
+"360 311 OFFCURVE",
+"259 311 CURVE SMOOTH",
+"163 311 OFFCURVE",
+"40 205 OFFCURVE",
+"40 106 CURVE SMOOTH",
+"40 25 OFFCURVE",
+"80 -119 OFFCURVE",
+"182 -119 CURVE SMOOTH",
+"215 -119 OFFCURVE",
+"265 -103 OFFCURVE",
+"285 -75 CURVE SMOOTH",
+"287 -72 OFFCURVE",
+"290 -67 OFFCURVE",
+"290 -63 CURVE SMOOTH",
+"290 -60 OFFCURVE",
+"288 -59 OFFCURVE",
+"286 -59 CURVE SMOOTH",
+"268 -59 OFFCURVE",
+"215 -95 OFFCURVE",
+"199 -95 CURVE SMOOTH",
+"113 -95 OFFCURVE",
+"80 15 OFFCURVE",
+"80 85 CURVE SMOOTH",
+"80 195 OFFCURVE",
+"141 285 OFFCURVE",
+"259 285 CURVE SMOOTH",
+"346 285 OFFCURVE",
+"455 244 OFFCURVE",
+"455 141 CURVE SMOOTH",
+"455 84 OFFCURVE",
+"452 9 OFFCURVE",
+"377 9 CURVE SMOOTH",
+"333 9 OFFCURVE",
+"344 111 OFFCURVE",
+"328 111 CURVE SMOOTH",
+"309 111 OFFCURVE",
+"264 11 OFFCURVE",
+"214 11 CURVE SMOOTH",
+"201 11 OFFCURVE",
+"196 71 OFFCURVE",
+"196 79 CURVE SMOOTH",
+"196 126 OFFCURVE",
+"214 171 OFFCURVE",
+"268 171 CURVE SMOOTH",
+"299 171 OFFCURVE",
+"330 164 OFFCURVE",
+"330 127 CURVE SMOOTH",
+"330 119 OFFCURVE",
+"335 114 OFFCURVE",
+"343 114 CURVE SMOOTH",
+"350 114 OFFCURVE",
+"356 119 OFFCURVE",
+"356 127 CURVE SMOOTH",
+"356 180 OFFCURVE",
+"314 197 OFFCURVE",
+"268 197 CURVE SMOOTH",
+"196 197 OFFCURVE",
+"153 137 OFFCURVE",
+"153 69 CURVE SMOOTH",
+"153 32 OFFCURVE",
+"170 -15 OFFCURVE",
+"214 -15 CURVE SMOOTH",
+"247 -15 OFFCURVE",
+"287 17 OFFCURVE",
+"307 41 CURVE",
+"319 7 OFFCURVE",
+"350 -4 OFFCURVE",
+"384 -4 CURVE SMOOTH",
+"473 -4 OFFCURVE",
+"498 63 OFFCURVE",
+"498 140 CURVE SMOOTH"
+);
+}
+);
+width = 544;
+}
+);
+note = at;
+unicode = 0040;
+},
+{
+glyphname = ampersand;
+lastChange = "2022-02-08 12:52:23 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"641 37 OFFCURVE",
+"618 31 OFFCURVE",
+"596 31 CURVE SMOOTH",
+"579 31 OFFCURVE",
+"562 34 OFFCURVE",
+"546 40 CURVE",
+"591 77 OFFCURVE",
+"625 126 OFFCURVE",
+"625 177 CURVE SMOOTH",
+"625 303 OFFCURVE",
+"522 385 OFFCURVE",
+"403 385 CURVE SMOOTH",
+"341 385 OFFCURVE",
+"277 349 OFFCURVE",
+"239 296 CURVE",
+"217 331 OFFCURVE",
+"201 371 OFFCURVE",
+"193 409 CURVE",
+"202 417 OFFCURVE",
+"211 425 OFFCURVE",
+"222 433 CURVE SMOOTH",
+"278 475 OFFCURVE",
+"381 505 OFFCURVE",
+"425 557 CURVE SMOOTH",
+"436 570 OFFCURVE",
+"441 583 OFFCURVE",
+"441 594 CURVE SMOOTH",
+"441 623 OFFCURVE",
+"407 643 OFFCURVE",
+"365 643 CURVE SMOOTH",
+"354 643 OFFCURVE",
+"343 642 OFFCURVE",
+"332 639 CURVE SMOOTH",
+"244 619 OFFCURVE",
+"128 538 OFFCURVE",
+"128 451 CURVE SMOOTH",
+"128 434 OFFCURVE",
+"131 416 OFFCURVE",
+"137 398 CURVE",
+"83 341 OFFCURVE",
+"47 272 OFFCURVE",
+"47 176 CURVE SMOOTH",
+"47 134 OFFCURVE",
+"64 76 OFFCURVE",
+"92 49 CURVE SMOOTH",
+"178 -34 OFFCURVE",
+"252 -33 OFFCURVE",
+"374 -33 CURVE SMOOTH",
+"415 -33 OFFCURVE",
+"472 -12 OFFCURVE",
+"521 21 CURVE",
+"550 11 OFFCURVE",
+"579 4 OFFCURVE",
+"606 4 CURVE SMOOTH",
+"621 4 OFFCURVE",
+"635 6 OFFCURVE",
+"649 10 CURVE SMOOTH",
+"678 18 OFFCURVE",
+"687 30 OFFCURVE",
+"687 39 CURVE SMOOTH",
+"687 49 OFFCURVE",
+"674 56 OFFCURVE",
+"665 51 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"377 569 OFFCURVE",
+"306 524 OFFCURVE",
+"286 512 CURVE SMOOTH",
+"252 491 OFFCURVE",
+"219 469 OFFCURVE",
+"189 445 CURVE",
+"189 447 OFFCURVE",
+"189 450 OFFCURVE",
+"189 452 CURVE SMOOTH",
+"189 529 OFFCURVE",
+"316 598 OFFCURVE",
+"373 598 CURVE SMOOTH",
+"381 598 OFFCURVE",
+"387 597 OFFCURVE",
+"392 594 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"595 133 OFFCURVE",
+"560 88 OFFCURVE",
+"516 54 CURVE",
+"476 76 OFFCURVE",
+"439 111 OFFCURVE",
+"403 142 CURVE SMOOTH",
+"360 180 OFFCURVE",
+"324 205 OFFCURVE",
+"290 234 CURVE SMOOTH",
+"278 244 OFFCURVE",
+"267 256 OFFCURVE",
+"257 270 CURVE",
+"288 320 OFFCURVE",
+"347 355 OFFCURVE",
+"403 355 CURVE SMOOTH",
+"508 355 OFFCURVE",
+"595 283 OFFCURVE",
+"595 177 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"449 12 OFFCURVE",
+"407 -3 OFFCURVE",
+"374 -3 CURVE SMOOTH",
+"281 -3 OFFCURVE",
+"202 18 OFFCURVE",
+"144 77 CURVE SMOOTH",
+"122 98 OFFCURVE",
+"120 127 OFFCURVE",
+"120 159 CURVE SMOOTH",
+"120 170 OFFCURVE",
+"120 181 OFFCURVE",
+"120 193 CURVE SMOOTH",
+"120 265 OFFCURVE",
+"124 316 OFFCURVE",
+"152 361 CURVE",
+"170 326 OFFCURVE",
+"194 292 OFFCURVE",
+"219 263 CURVE",
+"209 241 OFFCURVE",
+"203 216 OFFCURVE",
+"203 191 CURVE SMOOTH",
+"203 148 OFFCURVE",
+"230 72 OFFCURVE",
+"290 72 CURVE SMOOTH",
+"300 72 OFFCURVE",
+"304 77 OFFCURVE",
+"304 81 CURVE SMOOTH",
+"304 86 OFFCURVE",
+"298 92 OFFCURVE",
+"288 92 CURVE SMOOTH",
+"256 92 OFFCURVE",
+"233 148 OFFCURVE",
+"233 191 CURVE SMOOTH",
+"233 207 OFFCURVE",
+"236 223 OFFCURVE",
+"242 238 CURVE",
+"251 228 OFFCURVE",
+"261 219 OFFCURVE",
+"270 212 CURVE SMOOTH",
+"304 183 OFFCURVE",
+"322 154 OFFCURVE",
+"365 116 CURVE SMOOTH",
+"400 85 OFFCURVE",
+"443 56 OFFCURVE",
+"487 35 CURVE"
+);
+}
+);
+width = 695;
+}
+);
+note = ampersand;
+unicode = 0026;
+},
+{
+glyphname = paragraph;
+lastChange = "2022-02-10 14:32:54 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"349 617 OFFCURVE",
+"301 627 OFFCURVE",
+"257 627 CURVE SMOOTH",
+"162 627 OFFCURVE",
+"10 573 OFFCURVE",
+"10 458 CURVE SMOOTH",
+"10 387 OFFCURVE",
+"78 312 OFFCURVE",
+"133 275 CURVE SMOOTH",
+"154 260 OFFCURVE",
+"184 245 OFFCURVE",
+"210 245 CURVE SMOOTH",
+"218 245 OFFCURVE",
+"233 246 OFFCURVE",
+"233 253 CURVE SMOOTH",
+"233 262 OFFCURVE",
+"214 272 OFFCURVE",
+"208 276 CURVE SMOOTH",
+"153 309 OFFCURVE",
+"45 372 OFFCURVE",
+"45 448 CURVE SMOOTH",
+"45 546 OFFCURVE",
+"221 585 OFFCURVE",
+"296 585 CURVE SMOOTH",
+"314 585 OFFCURVE",
+"333 583 OFFCURVE",
+"350 578 CURVE",
+"382 526 OFFCURVE",
+"387 443 OFFCURVE",
+"387 383 CURVE SMOOTH",
+"387 236 OFFCURVE",
+"358 91 OFFCURVE",
+"343 -55 CURVE",
+"342 -58 OFFCURVE",
+"342 -61 OFFCURVE",
+"342 -64 CURVE SMOOTH",
+"342 -71 OFFCURVE",
+"344 -85 OFFCURVE",
+"354 -85 CURVE SMOOTH",
+"369 -85 OFFCURVE",
+"376 -68 OFFCURVE",
+"378 -57 CURVE SMOOTH",
+"381 -46 OFFCURVE",
+"382 -32 OFFCURVE",
+"384 -20 CURVE SMOOTH",
+"388 11 OFFCURVE",
+"393 42 OFFCURVE",
+"397 73 CURVE SMOOTH",
+"411 175 OFFCURVE",
+"422 277 OFFCURVE",
+"422 380 CURVE SMOOTH",
+"422 443 OFFCURVE",
+"418 534 OFFCURVE",
+"385 590 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"340 526 OFFCURVE",
+"337 539 OFFCURVE",
+"307 539 CURVE SMOOTH",
+"301 539 OFFCURVE",
+"292 538 OFFCURVE",
+"292 529 CURVE SMOOTH",
+"292 520 OFFCURVE",
+"294 510 OFFCURVE",
+"294 501 CURVE SMOOTH",
+"296 476 OFFCURVE",
+"296 452 OFFCURVE",
+"296 428 CURVE SMOOTH",
+"296 277 OFFCURVE",
+"282 -56 OFFCURVE",
+"226 -190 CURVE SMOOTH",
+"224 -196 OFFCURVE",
+"221 -201 OFFCURVE",
+"221 -208 CURVE SMOOTH",
+"221 -213 OFFCURVE",
+"224 -216 OFFCURVE",
+"230 -216 CURVE SMOOTH",
+"244 -216 OFFCURVE",
+"265 -199 OFFCURVE",
+"270 -186 CURVE SMOOTH",
+"281 -159 OFFCURVE",
+"286 -126 OFFCURVE",
+"292 -98 CURVE SMOOTH",
+"310 -5 OFFCURVE",
+"320 89 OFFCURVE",
+"327 183 CURVE SMOOTH",
+"335 291 OFFCURVE",
+"340 400 OFFCURVE",
+"340 508 CURVE SMOOTH"
+);
+}
+);
+width = 498;
+}
+);
+note = paragraph;
+unicode = 00B6;
+},
+{
+glyphname = section;
+lastChange = "2022-02-10 14:33:01 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"537 115 OFFCURVE",
+"532 142 OFFCURVE",
+"522 165 CURVE SMOOTH",
+"439 338 OFFCURVE",
+"130 300 OFFCURVE",
+"130 401 CURVE SMOOTH",
+"130 458 OFFCURVE",
+"233 490 OFFCURVE",
+"277 499 CURVE SMOOTH",
+"302 505 OFFCURVE",
+"328 508 OFFCURVE",
+"355 508 CURVE SMOOTH",
+"376 508 OFFCURVE",
+"399 506 OFFCURVE",
+"419 498 CURVE",
+"429 468 OFFCURVE",
+"450 405 OFFCURVE",
+"489 405 CURVE SMOOTH",
+"506 405 OFFCURVE",
+"516 417 OFFCURVE",
+"516 434 CURVE SMOOTH",
+"516 478 OFFCURVE",
+"463 515 OFFCURVE",
+"429 535 CURVE",
+"423 549 OFFCURVE",
+"421 568 OFFCURVE",
+"421 583 CURVE SMOOTH",
+"421 593 OFFCURVE",
+"424 603 OFFCURVE",
+"424 612 CURVE SMOOTH",
+"424 614 OFFCURVE",
+"423 616 OFFCURVE",
+"421 616 CURVE SMOOTH",
+"410 616 OFFCURVE",
+"408 582 OFFCURVE",
+"408 575 CURVE SMOOTH",
+"408 564 OFFCURVE",
+"409 552 OFFCURVE",
+"412 541 CURVE",
+"386 548 OFFCURVE",
+"360 551 OFFCURVE",
+"334 551 CURVE SMOOTH",
+"278 551 OFFCURVE",
+"216 537 OFFCURVE",
+"168 509 CURVE SMOOTH",
+"129 486 OFFCURVE",
+"81 449 OFFCURVE",
+"81 400 CURVE SMOOTH",
+"81 377 OFFCURVE",
+"92 356 OFFCURVE",
+"109 340 CURVE",
+"67 319 OFFCURVE",
+"42 290 OFFCURVE",
+"42 242 CURVE SMOOTH",
+"42 100 OFFCURVE",
+"437 121 OFFCURVE",
+"437 -31 CURVE SMOOTH",
+"437 -139 OFFCURVE",
+"232 -229 OFFCURVE",
+"140 -229 CURVE SMOOTH",
+"98 -229 OFFCURVE",
+"61 -215 OFFCURVE",
+"61 -167 CURVE SMOOTH",
+"61 -94 OFFCURVE",
+"130 -4 OFFCURVE",
+"207 -4 CURVE SMOOTH",
+"224 -4 OFFCURVE",
+"248 -10 OFFCURVE",
+"248 -31 CURVE SMOOTH",
+"248 -60 OFFCURVE",
+"188 -101 OFFCURVE",
+"162 -101 CURVE SMOOTH",
+"156 -101 OFFCURVE",
+"152 -99 OFFCURVE",
+"148 -94 CURVE SMOOTH",
+"147 -93 OFFCURVE",
+"143 -83 OFFCURVE",
+"142 -83 CURVE SMOOTH",
+"138 -83 OFFCURVE",
+"136 -93 OFFCURVE",
+"136 -96 CURVE SMOOTH",
+"136 -113 OFFCURVE",
+"151 -120 OFFCURVE",
+"166 -120 CURVE SMOOTH",
+"201 -120 OFFCURVE",
+"270 -89 OFFCURVE",
+"270 -47 CURVE SMOOTH",
+"270 -7 OFFCURVE",
+"212 16 OFFCURVE",
+"179 16 CURVE SMOOTH",
+"161 16 OFFCURVE",
+"142 12 OFFCURVE",
+"126 4 CURVE SMOOTH",
+"80 -17 OFFCURVE",
+"31 -92 OFFCURVE",
+"31 -142 CURVE SMOOTH",
+"31 -216 OFFCURVE",
+"78 -256 OFFCURVE",
+"150 -256 CURVE SMOOTH",
+"264 -256 OFFCURVE",
+"407 -196 OFFCURVE",
+"455 -85 CURVE",
+"468 -83 OFFCURVE",
+"476 -68 OFFCURVE",
+"483 -59 CURVE SMOOTH",
+"514 -15 OFFCURVE",
+"537 36 OFFCURVE",
+"537 90 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"504 37 OFFCURVE",
+"488 0 OFFCURVE",
+"467 -28 CURVE",
+"469 166 OFFCURVE",
+"91 160 OFFCURVE",
+"71 248 CURVE",
+"71 252 OFFCURVE",
+"70 256 OFFCURVE",
+"70 260 CURVE SMOOTH",
+"70 301 OFFCURVE",
+"114 302 OFFCURVE",
+"136 318 CURVE",
+"154 306 OFFCURVE",
+"175 296 OFFCURVE",
+"196 290 CURVE SMOOTH",
+"296 265 OFFCURVE",
+"504 207 OFFCURVE",
+"504 72 CURVE SMOOTH"
+);
+}
+);
+width = 586;
+}
+);
+note = section;
+unicode = 00A7;
+},
+{
+glyphname = copyright;
+lastChange = "2022-02-10 14:33:05 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"202 283 OFFCURVE",
+"240 292 OFFCURVE",
+"260 318 CURVE SMOOTH",
+"274 336 OFFCURVE",
+"283 357 OFFCURVE",
+"283 380 CURVE SMOOTH",
+"283 419 OFFCURVE",
+"257 454 OFFCURVE",
+"227 477 CURVE",
+"230 478 OFFCURVE",
+"235 481 OFFCURVE",
+"235 485 CURVE SMOOTH",
+"235 493 OFFCURVE",
+"217 495 OFFCURVE",
+"211 495 CURVE SMOOTH",
+"208 495 OFFCURVE",
+"204 495 OFFCURVE",
+"200 494 CURVE",
+"192 498 OFFCURVE",
+"182 500 OFFCURVE",
+"173 500 CURVE SMOOTH",
+"146 500 OFFCURVE",
+"94 484 OFFCURVE",
+"90 452 CURVE",
+"68 432 OFFCURVE",
+"55 404 OFFCURVE",
+"55 375 CURVE SMOOTH",
+"55 309 OFFCURVE",
+"112 283 OFFCURVE",
+"170 283 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 324 OFFCURVE",
+"217 297 OFFCURVE",
+"164 297 CURVE SMOOTH",
+"118 297 OFFCURVE",
+"75 321 OFFCURVE",
+"75 372 CURVE SMOOTH",
+"75 436 OFFCURVE",
+"148 472 OFFCURVE",
+"202 481 CURVE",
+"237 470 OFFCURVE",
+"273 421 OFFCURVE",
+"273 385 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"233 351 OFFCURVE",
+"236 357 OFFCURVE",
+"236 360 CURVE SMOOTH",
+"236 362 OFFCURVE",
+"235 363 OFFCURVE",
+"234 363 CURVE SMOOTH",
+"234 363 OFFCURVE",
+"233 362 OFFCURVE",
+"231 361 CURVE",
+"217 342 OFFCURVE",
+"195 332 OFFCURVE",
+"175 332 CURVE SMOOTH",
+"149 332 OFFCURVE",
+"142 351 OFFCURVE",
+"142 368 CURVE SMOOTH",
+"142 403 OFFCURVE",
+"165 453 OFFCURVE",
+"193 442 CURVE SMOOTH",
+"198 440 OFFCURVE",
+"200 436 OFFCURVE",
+"200 432 CURVE SMOOTH",
+"200 430 OFFCURVE",
+"199 428 OFFCURVE",
+"199 425 CURVE",
+"199 418 OFFCURVE",
+"190 408 OFFCURVE",
+"187 394 CURVE",
+"184 387 OFFCURVE",
+"191 387 OFFCURVE",
+"196 392 CURVE",
+"202 406 OFFCURVE",
+"211 423 OFFCURVE",
+"212 433 CURVE SMOOTH",
+"214 440 OFFCURVE",
+"214 451 OFFCURVE",
+"209 455 CURVE SMOOTH",
+"205 459 OFFCURVE",
+"198 461 OFFCURVE",
+"191 461 CURVE SMOOTH",
+"188 461 OFFCURVE",
+"185 461 OFFCURVE",
+"182 459 CURVE SMOOTH",
+"140 441 OFFCURVE",
+"119 399 OFFCURVE",
+"119 371 CURVE SMOOTH",
+"119 326 OFFCURVE",
+"142 315 OFFCURVE",
+"167 315 CURVE SMOOTH",
+"191 315 OFFCURVE",
+"217 330 OFFCURVE",
+"232 350 CURVE SMOOTH"
+);
+}
+);
+width = 281;
+}
+);
+note = copyright;
+unicode = 00A9;
+},
+{
+glyphname = registered;
+lastChange = "2022-02-10 14:33:07 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"202 283 OFFCURVE",
+"240 292 OFFCURVE",
+"260 318 CURVE SMOOTH",
+"274 336 OFFCURVE",
+"283 357 OFFCURVE",
+"283 380 CURVE SMOOTH",
+"283 419 OFFCURVE",
+"257 454 OFFCURVE",
+"227 477 CURVE",
+"230 478 OFFCURVE",
+"235 481 OFFCURVE",
+"235 485 CURVE SMOOTH",
+"235 493 OFFCURVE",
+"217 495 OFFCURVE",
+"211 495 CURVE SMOOTH",
+"208 495 OFFCURVE",
+"204 495 OFFCURVE",
+"200 494 CURVE",
+"192 498 OFFCURVE",
+"182 500 OFFCURVE",
+"173 500 CURVE SMOOTH",
+"146 500 OFFCURVE",
+"94 484 OFFCURVE",
+"90 452 CURVE",
+"68 432 OFFCURVE",
+"55 404 OFFCURVE",
+"55 375 CURVE SMOOTH",
+"55 309 OFFCURVE",
+"112 283 OFFCURVE",
+"170 283 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 324 OFFCURVE",
+"217 297 OFFCURVE",
+"164 297 CURVE SMOOTH",
+"118 297 OFFCURVE",
+"75 321 OFFCURVE",
+"75 372 CURVE SMOOTH",
+"75 436 OFFCURVE",
+"148 472 OFFCURVE",
+"202 481 CURVE",
+"237 470 OFFCURVE",
+"273 421 OFFCURVE",
+"273 385 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"229 442 OFFCURVE",
+"210 446 OFFCURVE",
+"198 446 CURVE SMOOTH",
+"162 446 LINE SMOOTH",
+"154 446 OFFCURVE",
+"130 445 OFFCURVE",
+"129 433 CURVE SMOOTH",
+"127 404 OFFCURVE",
+"126 366 OFFCURVE",
+"126 336 CURVE SMOOTH",
+"126 331 OFFCURVE",
+"129 327 OFFCURVE",
+"134 327 CURVE SMOOTH",
+"139 327 OFFCURVE",
+"149 333 OFFCURVE",
+"149 338 CURVE SMOOTH",
+"149 344 OFFCURVE",
+"147 352 OFFCURVE",
+"146 359 CURVE SMOOTH",
+"144 376 OFFCURVE",
+"142 394 OFFCURVE",
+"142 411 CURVE SMOOTH",
+"142 415 OFFCURVE",
+"142 420 OFFCURVE",
+"142 424 CURVE",
+"153 426 OFFCURVE",
+"165 427 OFFCURVE",
+"176 427 CURVE SMOOTH",
+"182 427 OFFCURVE",
+"201 427 OFFCURVE",
+"201 418 CURVE SMOOTH",
+"201 401 OFFCURVE",
+"149 394 OFFCURVE",
+"149 381 CURVE",
+"148 380 OFFCURVE",
+"148 378 OFFCURVE",
+"148 377 CURVE SMOOTH",
+"148 366 OFFCURVE",
+"210 338 OFFCURVE",
+"219 338 CURVE SMOOTH",
+"221 338 OFFCURVE",
+"226 338 OFFCURVE",
+"226 341 CURVE SMOOTH",
+"226 344 OFFCURVE",
+"222 346 OFFCURVE",
+"220 347 CURVE SMOOTH",
+"202 357 OFFCURVE",
+"185 367 OFFCURVE",
+"169 379 CURVE",
+"170 379 LINE",
+"188 388 OFFCURVE",
+"229 403 OFFCURVE",
+"229 427 CURVE SMOOTH"
+);
+}
+);
+width = 281;
+}
+);
+note = registered;
+unicode = 00AE;
+},
+{
+glyphname = trademark;
+lastChange = "2022-02-10 14:33:10 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"454 322 OFFCURVE",
+"451 328 OFFCURVE",
+"448 333 CURVE SMOOTH",
+"444 340 LINE SMOOTH",
+"422 381 OFFCURVE",
+"405 461 OFFCURVE",
+"405 507 CURVE SMOOTH",
+"405 511 OFFCURVE",
+"402 514 OFFCURVE",
+"396 514 CURVE SMOOTH",
+"390 514 OFFCURVE",
+"386 512 OFFCURVE",
+"384 508 CURVE",
+"384 505 OFFCURVE",
+"383 502 OFFCURVE",
+"383 500 CURVE SMOOTH",
+"383 498 OFFCURVE",
+"383 495 OFFCURVE",
+"382 493 CURVE SMOOTH",
+"381 489 OFFCURVE",
+"381 485 OFFCURVE",
+"380 481 CURVE SMOOTH",
+"379 478 OFFCURVE",
+"378 475 OFFCURVE",
+"378 471 CURVE",
+"366 432 OFFCURVE",
+"339 367 OFFCURVE",
+"307 339 CURVE",
+"277 374 OFFCURVE",
+"264 461 OFFCURVE",
+"264 507 CURVE SMOOTH",
+"264 511 OFFCURVE",
+"261 514 OFFCURVE",
+"255 514 CURVE SMOOTH",
+"248 514 OFFCURVE",
+"244 511 OFFCURVE",
+"243 507 CURVE SMOOTH",
+"243 503 OFFCURVE",
+"243 499 OFFCURVE",
+"242 497 CURVE SMOOTH",
+"241 494 OFFCURVE",
+"241 491 OFFCURVE",
+"240 488 CURVE SMOOTH",
+"239 483 OFFCURVE",
+"238 479 OFFCURVE",
+"236 474 CURVE SMOOTH",
+"222 430 OFFCURVE",
+"188 357 OFFCURVE",
+"147 336 CURVE",
+"146 335 LINE SMOOTH",
+"145 334 OFFCURVE",
+"144 333 OFFCURVE",
+"144 331 CURVE SMOOTH",
+"144 325 OFFCURVE",
+"156 312 OFFCURVE",
+"163 312 CURVE SMOOTH",
+"164 312 OFFCURVE",
+"165 312 OFFCURVE",
+"165 313 CURVE",
+"200 329 OFFCURVE",
+"230 404 OFFCURVE",
+"244 442 CURVE",
+"252 409 OFFCURVE",
+"280 312 OFFCURVE",
+"303 312 CURVE SMOOTH",
+"306 312 LINE",
+"340 329 OFFCURVE",
+"377 403 OFFCURVE",
+"392 441 CURVE",
+"394 426 OFFCURVE",
+"398 410 OFFCURVE",
+"401 394 CURVE SMOOTH",
+"405 370 OFFCURVE",
+"423 319 OFFCURVE",
+"443 303 CURVE",
+"445 300 OFFCURVE",
+"450 297 OFFCURVE",
+"454 297 CURVE SMOOTH",
+"460 297 OFFCURVE",
+"464 301 OFFCURVE",
+"464 307 CURVE SMOOTH",
+"464 311 OFFCURVE",
+"462 314 OFFCURVE",
+"458 317 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"124 368 OFFCURVE",
+"123 393 OFFCURVE",
+"123 419 CURVE SMOOTH",
+"123 439 OFFCURVE",
+"124 458 OFFCURVE",
+"125 478 CURVE",
+"142 479 OFFCURVE",
+"200 483 OFFCURVE",
+"209 487 CURVE SMOOTH",
+"213 488 OFFCURVE",
+"216 492 OFFCURVE",
+"216 498 CURVE SMOOTH",
+"216 505 OFFCURVE",
+"211 512 OFFCURVE",
+"205 512 CURVE SMOOTH",
+"203 512 LINE",
+"190 509 OFFCURVE",
+"174 508 OFFCURVE",
+"159 507 CURVE SMOOTH",
+"147 506 OFFCURVE",
+"136 506 OFFCURVE",
+"126 504 CURVE",
+"124 509 OFFCURVE",
+"121 511 OFFCURVE",
+"118 511 CURVE SMOOTH",
+"112 511 OFFCURVE",
+"108 506 OFFCURVE",
+"105 503 CURVE",
+"101 503 LINE SMOOTH",
+"76 503 OFFCURVE",
+"50 503 OFFCURVE",
+"25 507 CURVE SMOOTH",
+"23 507 LINE SMOOTH",
+"17 507 OFFCURVE",
+"13 501 OFFCURVE",
+"13 493 CURVE SMOOTH",
+"13 487 OFFCURVE",
+"15 484 OFFCURVE",
+"20 481 CURVE",
+"33 477 OFFCURVE",
+"83 476 OFFCURVE",
+"98 476 CURVE SMOOTH",
+"104 476 LINE",
+"104 450 LINE",
+"104 374 LINE SMOOTH",
+"103 348 OFFCURVE",
+"103 322 OFFCURVE",
+"103 296 CURVE SMOOTH",
+"103 285 OFFCURVE",
+"106 279 OFFCURVE",
+"113 279 CURVE SMOOTH",
+"123 279 OFFCURVE",
+"133 289 OFFCURVE",
+"133 299 CURVE SMOOTH",
+"133 307 OFFCURVE",
+"132 316 OFFCURVE",
+"130 325 CURVE SMOOTH",
+"129 331 OFFCURVE",
+"128 337 OFFCURVE",
+"128 343 CURVE"
+);
+}
+);
+width = 517;
+}
+);
+note = trademark;
+unicode = 2122;
+},
+{
+glyphname = degree;
+lastChange = "2022-02-10 16:03:22 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"239 572 OFFCURVE",
+"194 537 OFFCURVE",
+"171 537 CURVE SMOOTH",
+"148 537 OFFCURVE",
+"133 561 OFFCURVE",
+"133 582 CURVE SMOOTH",
+"133 615 OFFCURVE",
+"157 641 OFFCURVE",
+"191 641 CURVE SMOOTH",
+"217 641 OFFCURVE",
+"239 624 OFFCURVE",
+"239 596 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"267 640 OFFCURVE",
+"235 669 OFFCURVE",
+"192 669 CURVE SMOOTH",
+"142 669 OFFCURVE",
+"106 632 OFFCURVE",
+"106 582 CURVE SMOOTH",
+"106 545 OFFCURVE",
+"132 509 OFFCURVE",
+"171 509 CURVE SMOOTH",
+"209 509 OFFCURVE",
+"267 556 OFFCURVE",
+"267 596 CURVE SMOOTH"
+);
+}
+);
+width = 338;
+}
+);
+note = degree;
+unicode = 00B0;
+},
+{
+glyphname = minute;
+lastChange = "2022-02-10 14:33:20 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"81 457 OFFCURVE",
+"87 468 OFFCURVE",
+"97 490 CURVE SMOOTH",
+"117 529 OFFCURVE",
+"132 567 OFFCURVE",
+"141 612 CURVE SMOOTH",
+"142 615 OFFCURVE",
+"143 619 OFFCURVE",
+"143 622 CURVE SMOOTH",
+"143 626 OFFCURVE",
+"142 630 OFFCURVE",
+"139 632 CURVE SMOOTH",
+"133 637 OFFCURVE",
+"121 640 OFFCURVE",
+"111 640 CURVE SMOOTH",
+"107 640 OFFCURVE",
+"104 639 OFFCURVE",
+"103 635 CURVE SMOOTH",
+"92 584 OFFCURVE",
+"74 525 OFFCURVE",
+"56 474 CURVE SMOOTH",
+"53 466 OFFCURVE",
+"55 459 OFFCURVE",
+"61 454 CURVE SMOOTH",
+"63 452 OFFCURVE",
+"66 450 OFFCURVE",
+"69 450 CURVE SMOOTH",
+"71 450 OFFCURVE",
+"73 451 OFFCURVE",
+"75 453 CURVE"
+);
+}
+);
+width = 158;
+}
+);
+leftKerningGroup = quotes;
+rightKerningGroup = quotes;
+unicode = 2032;
+},
+{
+glyphname = second;
+lastChange = "2022-02-10 14:33:22 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"205 457 OFFCURVE",
+"211 468 OFFCURVE",
+"221 490 CURVE SMOOTH",
+"241 529 OFFCURVE",
+"256 567 OFFCURVE",
+"265 612 CURVE SMOOTH",
+"266 615 OFFCURVE",
+"267 619 OFFCURVE",
+"267 622 CURVE SMOOTH",
+"267 626 OFFCURVE",
+"266 630 OFFCURVE",
+"263 632 CURVE SMOOTH",
+"257 637 OFFCURVE",
+"245 640 OFFCURVE",
+"235 640 CURVE SMOOTH",
+"231 640 OFFCURVE",
+"228 639 OFFCURVE",
+"227 635 CURVE SMOOTH",
+"216 584 OFFCURVE",
+"198 525 OFFCURVE",
+"180 474 CURVE SMOOTH",
+"177 466 OFFCURVE",
+"179 459 OFFCURVE",
+"185 454 CURVE SMOOTH",
+"187 452 OFFCURVE",
+"190 450 OFFCURVE",
+"193 450 CURVE SMOOTH",
+"195 450 OFFCURVE",
+"197 451 OFFCURVE",
+"199 453 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"81 457 OFFCURVE",
+"87 468 OFFCURVE",
+"97 490 CURVE SMOOTH",
+"117 529 OFFCURVE",
+"132 567 OFFCURVE",
+"141 612 CURVE SMOOTH",
+"142 615 OFFCURVE",
+"143 619 OFFCURVE",
+"143 622 CURVE SMOOTH",
+"143 626 OFFCURVE",
+"142 630 OFFCURVE",
+"139 632 CURVE SMOOTH",
+"133 637 OFFCURVE",
+"121 640 OFFCURVE",
+"111 640 CURVE SMOOTH",
+"107 640 OFFCURVE",
+"104 639 OFFCURVE",
+"103 635 CURVE SMOOTH",
+"92 584 OFFCURVE",
+"74 525 OFFCURVE",
+"56 474 CURVE SMOOTH",
+"53 466 OFFCURVE",
+"55 459 OFFCURVE",
+"61 454 CURVE SMOOTH",
+"63 452 OFFCURVE",
+"66 450 OFFCURVE",
+"69 450 CURVE SMOOTH",
+"71 450 OFFCURVE",
+"73 451 OFFCURVE",
+"75 453 CURVE"
+);
+}
+);
+width = 282;
+}
+);
+leftKerningGroup = quotes;
+rightKerningGroup = quotes;
+unicode = 2033;
+},
+{
+glyphname = bar;
+lastChange = "2022-02-10 14:33:27 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"181 377 OFFCURVE",
+"184 508 OFFCURVE",
+"220 601 CURVE",
+"220 602 OFFCURVE",
+"221 603 OFFCURVE",
+"221 604 CURVE SMOOTH",
+"221 615 OFFCURVE",
+"201 617 OFFCURVE",
+"195 617 CURVE SMOOTH",
+"185 617 OFFCURVE",
+"180 615 OFFCURVE",
+"172 609 CURVE SMOOTH",
+"169 606 OFFCURVE",
+"164 604 OFFCURVE",
+"161 600 CURVE SMOOTH",
+"152 587 OFFCURVE",
+"151 554 OFFCURVE",
+"151 534 CURVE SMOOTH",
+"151 474 OFFCURVE",
+"153 415 OFFCURVE",
+"153 356 CURVE SMOOTH",
+"153 209 OFFCURVE",
+"150 62 OFFCURVE",
+"150 -84 CURVE SMOOTH",
+"150 -96 OFFCURVE",
+"153 -113 OFFCURVE",
+"168 -113 CURVE SMOOTH",
+"183 -113 OFFCURVE",
+"199 -96 OFFCURVE",
+"199 -80 CURVE SMOOTH",
+"199 -69 OFFCURVE",
+"197 -58 OFFCURVE",
+"196 -47 CURVE SMOOTH",
+"194 -20 OFFCURVE",
+"192 8 OFFCURVE",
+"190 35 CURVE SMOOTH",
+"185 116 OFFCURVE",
+"181 197 OFFCURVE",
+"181 278 CURVE SMOOTH"
+);
+}
+);
+width = 310;
+}
+);
+note = bar;
+unicode = 007C;
+},
+{
+glyphname = brokenbar;
+lastChange = "2022-02-10 14:33:35 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"181 330 LINE",
+"183 420 OFFCURVE",
+"190 524 OFFCURVE",
+"220 601 CURVE",
+"220 602 OFFCURVE",
+"221 603 OFFCURVE",
+"221 604 CURVE SMOOTH",
+"221 615 OFFCURVE",
+"201 617 OFFCURVE",
+"195 617 CURVE SMOOTH",
+"185 617 OFFCURVE",
+"180 615 OFFCURVE",
+"172 609 CURVE SMOOTH",
+"169 606 OFFCURVE",
+"164 604 OFFCURVE",
+"161 600 CURVE SMOOTH",
+"152 587 OFFCURVE",
+"151 554 OFFCURVE",
+"151 534 CURVE SMOOTH",
+"151 474 OFFCURVE",
+"153 415 OFFCURVE",
+"153 356 CURVE SMOOTH",
+"153 334 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"152 222 LINE",
+"151 120 OFFCURVE",
+"150 18 OFFCURVE",
+"150 -84 CURVE SMOOTH",
+"150 -96 OFFCURVE",
+"153 -113 OFFCURVE",
+"168 -113 CURVE SMOOTH",
+"183 -113 OFFCURVE",
+"199 -96 OFFCURVE",
+"199 -80 CURVE SMOOTH",
+"199 -69 OFFCURVE",
+"197 -58 OFFCURVE",
+"196 -47 CURVE SMOOTH",
+"190 35 LINE SMOOTH",
+"186 98 OFFCURVE",
+"183 160 OFFCURVE",
+"182 223 CURVE"
+);
+}
+);
+width = 310;
+}
+);
+note = brokenbar;
+unicode = 00A6;
+},
+{
+glyphname = dagger;
+lastChange = "2022-02-07 15:17:40 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"190 411 OFFCURVE",
+"236 418 OFFCURVE",
+"257 428 CURVE",
+"266 431 OFFCURVE",
+"269 437 OFFCURVE",
+"269 446 CURVE SMOOTH",
+"269 455 OFFCURVE",
+"263 468 OFFCURVE",
+"252 468 CURVE SMOOTH",
+"251 468 OFFCURVE",
+"250 468 OFFCURVE",
+"249 468 CURVE",
+"222 460 OFFCURVE",
+"196 454 OFFCURVE",
+"169 450 CURVE",
+"173 502 OFFCURVE",
+"181 552 OFFCURVE",
+"200 601 CURVE",
+"200 602 OFFCURVE",
+"201 603 OFFCURVE",
+"201 604 CURVE SMOOTH",
+"201 614 OFFCURVE",
+"182 617 OFFCURVE",
+"175 617 CURVE SMOOTH",
+"166 617 OFFCURVE",
+"159 615 OFFCURVE",
+"152 609 CURVE SMOOTH",
+"149 606 OFFCURVE",
+"145 604 OFFCURVE",
+"142 601 CURVE SMOOTH",
+"132 589 OFFCURVE",
+"131 553 OFFCURVE",
+"131 533 CURVE SMOOTH",
+"131 505 OFFCURVE",
+"132 476 OFFCURVE",
+"133 448 CURVE",
+"120 447 LINE SMOOTH",
+"95 447 OFFCURVE",
+"73 451 OFFCURVE",
+"48 455 CURVE SMOOTH",
+"47 455 OFFCURVE",
+"46 455 OFFCURVE",
+"45 455 CURVE SMOOTH",
+"34 455 OFFCURVE",
+"29 442 OFFCURVE",
+"29 433 CURVE SMOOTH",
+"29 424 OFFCURVE",
+"33 417 OFFCURVE",
+"42 414 CURVE SMOOTH",
+"66 407 OFFCURVE",
+"95 406 OFFCURVE",
+"120 406 CURVE SMOOTH",
+"133 406 LINE",
+"133 386 OFFCURVE",
+"133 366 OFFCURVE",
+"133 346 CURVE SMOOTH",
+"133 203 OFFCURVE",
+"130 59 OFFCURVE",
+"130 -84 CURVE SMOOTH",
+"130 -96 OFFCURVE",
+"133 -113 OFFCURVE",
+"148 -113 CURVE SMOOTH",
+"163 -113 OFFCURVE",
+"179 -96 OFFCURVE",
+"179 -80 CURVE SMOOTH",
+"179 -70 OFFCURVE",
+"177 -58 OFFCURVE",
+"176 -47 CURVE SMOOTH",
+"174 -21 OFFCURVE",
+"172 6 OFFCURVE",
+"170 33 CURVE SMOOTH",
+"165 112 OFFCURVE",
+"161 191 OFFCURVE",
+"161 270 CURVE SMOOTH",
+"161 316 OFFCURVE",
+"163 362 OFFCURVE",
+"166 408 CURVE"
+);
+}
+);
+width = 283;
+}
+);
+note = dagger;
+unicode = 2020;
+},
+{
+glyphname = daggerdbl;
+lastChange = "2022-02-07 15:17:40 +0000";
+layers = (
+{
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+paths = (
+{
+closed = 1;
+nodes = (
+"195 412 OFFCURVE",
+"230 417 OFFCURVE",
+"257 428 CURVE SMOOTH",
+"266 431 OFFCURVE",
+"269 437 OFFCURVE",
+"269 446 CURVE SMOOTH",
+"269 455 OFFCURVE",
+"263 468 OFFCURVE",
+"252 468 CURVE SMOOTH",
+"251 468 OFFCURVE",
+"250 468 OFFCURVE",
+"249 468 CURVE",
+"222 460 OFFCURVE",
+"196 454 OFFCURVE",
+"169 450 CURVE",
+"173 502 OFFCURVE",
+"181 552 OFFCURVE",
+"200 601 CURVE",
+"200 602 OFFCURVE",
+"201 603 OFFCURVE",
+"201 604 CURVE SMOOTH",
+"201 614 OFFCURVE",
+"182 617 OFFCURVE",
+"175 617 CURVE SMOOTH",
+"166 617 OFFCURVE",
+"158 615 OFFCURVE",
+"152 609 CURVE SMOOTH",
+"149 605 OFFCURVE",
+"144 604 OFFCURVE",
+"141 600 CURVE SMOOTH",
+"132 587 OFFCURVE",
+"131 554 OFFCURVE",
+"131 534 CURVE SMOOTH",
+"131 506 OFFCURVE",
+"132 476 OFFCURVE",
+"133 448 CURVE",
+"120 447 LINE SMOOTH",
+"95 447 OFFCURVE",
+"73 451 OFFCURVE",
+"48 455 CURVE SMOOTH",
+"47 455 OFFCURVE",
+"46 455 OFFCURVE",
+"45 455 CURVE SMOOTH",
+"34 455 OFFCURVE",
+"29 442 OFFCURVE",
+"29 433 CURVE SMOOTH",
+"29 424 OFFCURVE",
+"33 417 OFFCURVE",
+"42 414 CURVE SMOOTH",
+"66 407 OFFCURVE",
+"95 406 OFFCURVE",
+"120 406 CURVE SMOOTH",
+"133 406 LINE",
+"133 386 OFFCURVE",
+"133 366 OFFCURVE",
+"133 346 CURVE SMOOTH",
+"133 309 OFFCURVE",
+"133 272 OFFCURVE",
+"133 235 CURVE",
+"126 235 LINE SMOOTH",
+"99 234 OFFCURVE",
+"74 240 OFFCURVE",
+"47 245 CURVE SMOOTH",
+"46 245 OFFCURVE",
+"45 245 OFFCURVE",
+"44 245 CURVE SMOOTH",
+"33 245 OFFCURVE",
+"28 232 OFFCURVE",
+"28 223 CURVE SMOOTH",
+"28 214 OFFCURVE",
+"31 207 OFFCURVE",
+"40 204 CURVE SMOOTH",
+"64 197 OFFCURVE",
+"91 195 OFFCURVE",
+"116 195 CURVE SMOOTH",
+"132 196 LINE",
+"132 102 OFFCURVE",
+"130 9 OFFCURVE",
+"130 -84 CURVE SMOOTH",
+"130 -96 OFFCURVE",
+"133 -113 OFFCURVE",
+"148 -113 CURVE SMOOTH",
+"163 -113 OFFCURVE",
+"179 -96 OFFCURVE",
+"179 -80 CURVE SMOOTH",
+"179 -55 OFFCURVE",
+"174 -17 OFFCURVE",
+"172 10 CURVE SMOOTH",
+"167 72 OFFCURVE",
+"164 135 OFFCURVE",
+"162 198 CURVE",
+"193 201 OFFCURVE",
+"227 206 OFFCURVE",
+"256 217 CURVE SMOOTH",
+"264 220 OFFCURVE",
+"267 227 OFFCURVE",
+"267 235 CURVE SMOOTH",
+"267 244 OFFCURVE",
+"262 258 OFFCURVE",
+"251 258 CURVE SMOOTH",
+"250 258 OFFCURVE",
+"248 258 OFFCURVE",
+"247 257 CURVE",
+"219 249 OFFCURVE",
+"191 241 OFFCURVE",
+"162 237 CURVE",
+"161 270 LINE SMOOTH",
+"161 316 OFFCURVE",
+"163 362 OFFCURVE",
+"166 408 CURVE"
+);
+}
+);
+width = 305;
+}
+);
+note = daggerdbl;
+unicode = 2021;
+},
+{
+color = 3;
+glyphname = numero;
+lastChange = "2022-02-08 10:23:33 +0000";
 layers = (
 {
 anchors = (
 {
-name = _top;
-position = "{0, 300}";
-}
-);
-background = {
-anchors = (
-{
-name = _top;
-position = "{0, 255}";
-}
-);
-components = (
-{
-name = brevecomb;
+name = bottom;
+position = "{540, 0}";
 },
 {
-name = acutecomb;
-transform = "{1, 0, 0, 1, 0, 120}";
-}
-);
-};
-components = (
-{
-name = brevecomb;
-},
-{
-alignment = -1;
-name = acutecomb;
-transform = "{1, 0, 0, 1, 10, 90}";
+name = top;
+position = "{603, 565}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
+paths = (
+{
+closed = 1;
+nodes = (
+"838 28 OFFCURVE",
+"840 32 OFFCURVE",
+"840 35 CURVE SMOOTH",
+"840 43 OFFCURVE",
+"833 48 OFFCURVE",
+"823 51 CURVE",
+"807 52 OFFCURVE",
+"804 -11 OFFCURVE",
+"772 -4 CURVE SMOOTH",
+"763 -2 OFFCURVE",
+"749 -7 OFFCURVE",
+"734 -7 CURVE SMOOTH",
+"707 -7 OFFCURVE",
+"678 10 OFFCURVE",
+"678 123 CURVE SMOOTH",
+"678 192 OFFCURVE",
+"745 299 OFFCURVE",
+"745 386 CURVE SMOOTH",
+"745 399 OFFCURVE",
+"744 412 OFFCURVE",
+"740 424 CURVE SMOOTH",
+"723 484 OFFCURVE",
+"705 513 OFFCURVE",
+"672 536 CURVE SMOOTH",
+"662 542 OFFCURVE",
+"647 546 OFFCURVE",
+"630 546 CURVE SMOOTH",
+"608 546 OFFCURVE",
+"583 540 OFFCURVE",
+"564 523 CURVE",
+"542 492 OFFCURVE",
+"485 418 OFFCURVE",
+"484 365 CURVE SMOOTH",
+"484 343 OFFCURVE",
+"481 334 OFFCURVE",
+"477 334 CURVE SMOOTH",
+"472 334 OFFCURVE",
+"465 351 OFFCURVE",
+"460 372 CURVE",
+"426 465 OFFCURVE",
+"367 589 OFFCURVE",
+"241 589 CURVE SMOOTH",
+"227 589 OFFCURVE",
+"211 588 OFFCURVE",
+"195 584 CURVE SMOOTH",
+"111 567 OFFCURVE",
+"18 516 OFFCURVE",
+"18 400 CURVE SMOOTH",
+"18 371 OFFCURVE",
+"24 337 OFFCURVE",
+"38 298 CURVE SMOOTH",
+"64 228 OFFCURVE",
+"138 183 OFFCURVE",
+"199 183 CURVE SMOOTH",
+"212 183 OFFCURVE",
+"225 185 OFFCURVE",
+"236 189 CURVE SMOOTH",
+"267 200 OFFCURVE",
+"312 256 OFFCURVE",
+"312 310 CURVE SMOOTH",
+"312 351 OFFCURVE",
+"282 393 OFFCURVE",
+"256 404 CURVE SMOOTH",
+"246 409 OFFCURVE",
+"237 410 OFFCURVE",
+"231 410 CURVE SMOOTH",
+"220 410 OFFCURVE",
+"215 406 OFFCURVE",
+"215 400 CURVE SMOOTH",
+"215 395 OFFCURVE",
+"218 390 OFFCURVE",
+"225 387 CURVE SMOOTH",
+"254 372 OFFCURVE",
+"269 342 OFFCURVE",
+"269 310 CURVE SMOOTH",
+"269 272 OFFCURVE",
+"248 233 OFFCURVE",
+"205 218 CURVE SMOOTH",
+"201 216 OFFCURVE",
+"195 216 OFFCURVE",
+"189 216 CURVE SMOOTH",
+"148 216 OFFCURVE",
+"76 254 OFFCURVE",
+"58 304 CURVE SMOOTH",
+"46 337 OFFCURVE",
+"40 367 OFFCURVE",
+"40 393 CURVE SMOOTH",
+"40 496 OFFCURVE",
+"124 547 OFFCURVE",
+"203 560 CURVE SMOOTH",
+"214 562 OFFCURVE",
+"225 563 OFFCURVE",
+"235 563 CURVE SMOOTH",
+"313 563 OFFCURVE",
+"383 514 OFFCURVE",
+"407 412 CURVE SMOOTH",
+"420 354 OFFCURVE",
+"431 291 OFFCURVE",
+"431 221 CURVE SMOOTH",
+"431 153 OFFCURVE",
+"421 79 OFFCURVE",
+"393 -3 CURVE SMOOTH",
+"390 -13 OFFCURVE",
+"382 -34 OFFCURVE",
+"382 -47 CURVE SMOOTH",
+"382 -55 OFFCURVE",
+"385 -60 OFFCURVE",
+"391 -60 CURVE SMOOTH",
+"403 -60 OFFCURVE",
+"468 -47 OFFCURVE",
+"471 -18 CURVE SMOOTH",
+"475 23 OFFCURVE",
+"483 123 OFFCURVE",
+"496 235 CURVE SMOOTH",
+"513 387 OFFCURVE",
+"575 502 OFFCURVE",
+"615 507 CURVE SMOOTH",
+"657 513 OFFCURVE",
+"699 457 OFFCURVE",
+"699 396 CURVE SMOOTH",
+"699 386 OFFCURVE",
+"658 201 OFFCURVE",
+"652 92 CURVE SMOOTH",
+"648 31 OFFCURVE",
+"685 -8 OFFCURVE",
+"707 -20 CURVE SMOOTH",
+"716 -25 OFFCURVE",
+"728 -28 OFFCURVE",
+"742 -28 CURVE SMOOTH",
+"771 -28 OFFCURVE",
+"808 -14 OFFCURVE",
+"835 23 CURVE SMOOTH"
 );
 },
 {
-color = 1;
-glyphname = brevecomb_gravecomb;
-lastChange = "2022-02-17 10:26:18 +0000";
+closed = 1;
+nodes = (
+"986 529 OFFCURVE",
+"964 558 OFFCURVE",
+"925 558 CURVE SMOOTH",
+"910 558 OFFCURVE",
+"847 542 OFFCURVE",
+"818 487 CURVE SMOOTH",
+"814 479 OFFCURVE",
+"812 472 OFFCURVE",
+"812 464 CURVE SMOOTH",
+"812 451 OFFCURVE",
+"817 439 OFFCURVE",
+"826 429 CURVE",
+"823 418 OFFCURVE",
+"822 406 OFFCURVE",
+"822 395 CURVE SMOOTH",
+"822 359 OFFCURVE",
+"842 358 OFFCURVE",
+"849 352 CURVE SMOOTH",
+"853 348 OFFCURVE",
+"863 344 OFFCURVE",
+"873 344 CURVE SMOOTH",
+"878 344 OFFCURVE",
+"882 344 OFFCURVE",
+"886 346 CURVE SMOOTH",
+"902 353 OFFCURVE",
+"942 357 OFFCURVE",
+"964 405 CURVE SMOOTH",
+"979 436 OFFCURVE",
+"986 475 OFFCURVE",
+"986 496 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"950 472 OFFCURVE",
+"935 427 OFFCURVE",
+"922 403 CURVE SMOOTH",
+"908 377 OFFCURVE",
+"885 364 OFFCURVE",
+"871 370 CURVE SMOOTH",
+"861 375 OFFCURVE",
+"839 381 OFFCURVE",
+"840 412 CURVE SMOOTH",
+"840 414 OFFCURVE",
+"840 416 OFFCURVE",
+"841 417 CURVE",
+"846 413 OFFCURVE",
+"854 412 OFFCURVE",
+"862 412 CURVE SMOOTH",
+"879 412 OFFCURVE",
+"929 419 OFFCURVE",
+"929 447 CURVE SMOOTH",
+"929 453 OFFCURVE",
+"926 461 OFFCURVE",
+"920 469 CURVE",
+"914 476 OFFCURVE",
+"908 480 OFFCURVE",
+"903 480 CURVE SMOOTH",
+"900 480 OFFCURVE",
+"896 478 OFFCURVE",
+"893 475 CURVE SMOOTH",
+"891 473 OFFCURVE",
+"888 469 OFFCURVE",
+"888 467 CURVE SMOOTH",
+"888 464 OFFCURVE",
+"890 462 OFFCURVE",
+"898 462 CURVE SMOOTH",
+"906 463 OFFCURVE",
+"917 462 OFFCURVE",
+"917 452 CURVE SMOOTH",
+"917 450 OFFCURVE",
+"916 447 OFFCURVE",
+"915 444 CURVE SMOOTH",
+"911 433 OFFCURVE",
+"897 428 OFFCURVE",
+"882 428 CURVE SMOOTH",
+"868 428 OFFCURVE",
+"854 432 OFFCURVE",
+"845 442 CURVE",
+"859 480 OFFCURVE",
+"889 499 OFFCURVE",
+"889 505 CURVE SMOOTH",
+"889 508 OFFCURVE",
+"885 510 OFFCURVE",
+"880 510 CURVE SMOOTH",
+"877 510 OFFCURVE",
+"873 509 OFFCURVE",
+"870 507 CURVE SMOOTH",
+"864 502 OFFCURVE",
+"849 486 OFFCURVE",
+"838 461 CURVE",
+"838 466 OFFCURVE",
+"838 471 OFFCURVE",
+"839 477 CURVE SMOOTH",
+"845 501 OFFCURVE",
+"879 533 OFFCURVE",
+"909 533 CURVE SMOOTH",
+"932 533 OFFCURVE",
+"950 515 OFFCURVE",
+"950 492 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"962 282 OFFCURVE",
+"947 285 OFFCURVE",
+"922 285 CURVE SMOOTH",
+"894 285 OFFCURVE",
+"863 285 OFFCURVE",
+"828 285 CURVE SMOOTH",
+"810 285 OFFCURVE",
+"784 280 OFFCURVE",
+"771 280 CURVE SMOOTH",
+"763 280 OFFCURVE",
+"760 277 OFFCURVE",
+"760 273 CURVE SMOOTH",
+"760 268 OFFCURVE",
+"765 262 OFFCURVE",
+"773 258 CURVE SMOOTH",
+"778 256 OFFCURVE",
+"786 255 OFFCURVE",
+"794 255 CURVE SMOOTH",
+"803 255 OFFCURVE",
+"814 256 OFFCURVE",
+"823 256 CURVE SMOOTH",
+"828 256 OFFCURVE",
+"832 256 OFFCURVE",
+"836 255 CURVE",
+"860 253 OFFCURVE",
+"933 252 OFFCURVE",
+"959 252 CURVE SMOOTH",
+"969 252 OFFCURVE",
+"978 260 OFFCURVE",
+"978 268 CURVE SMOOTH",
+"978 272 OFFCURVE",
+"975 276 OFFCURVE",
+"969 278 CURVE"
+);
+}
+);
+width = 1002;
+}
+);
+unicode = 2116;
+},
+{
+glyphname = apostrophemod;
+lastChange = "2022-02-08 10:30:40 +0000";
 layers = (
 {
-anchors = (
-{
-name = _top;
-position = "{0, 300}";
-}
-);
-background = {
-anchors = (
-{
-name = _top;
-position = "{0, 255}";
-}
-);
-components = (
-{
-name = brevecomb;
-},
-{
-name = gravecomb;
-transform = "{1, 0, 0, 1, 0, 120}";
-}
-);
-};
-components = (
-{
-name = brevecomb;
-},
-{
-alignment = -1;
-name = gravecomb;
-transform = "{1, 0, 0, 1, 10, 90}";
-}
-);
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
+paths = (
+{
+closed = 1;
+nodes = (
+"0 920 OFFCURVE"
 );
 },
 {
-color = 1;
-glyphname = brevecomb_hookabovecomb;
-lastChange = "2022-02-17 10:26:18 +0000";
+closed = 1;
+nodes = (
+"29 711 OFFCURVE",
+"32 722 OFFCURVE",
+"38 745 CURVE SMOOTH",
+"49 785 OFFCURVE",
+"56 844 OFFCURVE",
+"56 889 CURVE SMOOTH",
+"56 895 OFFCURVE",
+"56 904 OFFCURVE",
+"49 909 CURVE SMOOTH",
+"44 913 OFFCURVE",
+"33 916 OFFCURVE",
+"24 916 CURVE SMOOTH",
+"18 916 OFFCURVE",
+"13 915 OFFCURVE",
+"13 910 CURVE SMOOTH",
+"13 859 OFFCURVE",
+"7 779 OFFCURVE",
+"0 727 CURVE SMOOTH",
+"-1 719 OFFCURVE",
+"2 712 OFFCURVE",
+"9 707 CURVE SMOOTH",
+"13 703 OFFCURVE",
+"20 703 OFFCURVE",
+"23 707 CURVE"
+);
+}
+);
+width = 56;
+}
+);
+unicode = 02BC;
+},
+{
+glyphname = doubleprimemod;
+lastChange = "2022-02-08 10:30:40 +0000";
 layers = (
 {
-anchors = (
-{
-name = _top;
-position = "{0, 300}";
-}
-);
-background = {
-anchors = (
-{
-name = _top;
-position = "{0, 255}";
-}
-);
-components = (
-{
-name = brevecomb;
-},
-{
-name = hookabovecomb;
-transform = "{1, 0, 0, 1, 0, 120}";
-}
-);
-};
-components = (
-{
-name = brevecomb;
-},
-{
-alignment = -1;
-name = hookabovecomb;
-transform = "{1, 0, 0, 1, 10, 80}";
-}
-);
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
+paths = (
+{
+closed = 1;
+nodes = (
+"29 731 OFFCURVE",
+"32 742 OFFCURVE",
+"38 765 CURVE SMOOTH",
+"49 805 OFFCURVE",
+"56 844 OFFCURVE",
+"56 889 CURVE SMOOTH",
+"56 895 OFFCURVE",
+"56 904 OFFCURVE",
+"49 909 CURVE SMOOTH",
+"44 913 OFFCURVE",
+"33 916 OFFCURVE",
+"24 916 CURVE SMOOTH",
+"18 916 OFFCURVE",
+"13 915 OFFCURVE",
+"13 910 CURVE SMOOTH",
+"13 859 OFFCURVE",
+"7 799 OFFCURVE",
+"0 747 CURVE SMOOTH",
+"-1 739 OFFCURVE",
+"2 732 OFFCURVE",
+"9 727 CURVE SMOOTH",
+"13 723 OFFCURVE",
+"20 723 OFFCURVE",
+"23 727 CURVE"
 );
 },
 {
-color = 1;
-glyphname = brevecomb_tildecomb;
-lastChange = "2022-02-17 10:26:18 +0000";
+closed = 1;
+nodes = (
+"149 731 OFFCURVE",
+"152 742 OFFCURVE",
+"158 765 CURVE SMOOTH",
+"169 805 OFFCURVE",
+"176 844 OFFCURVE",
+"176 889 CURVE SMOOTH",
+"176 895 OFFCURVE",
+"176 904 OFFCURVE",
+"169 909 CURVE SMOOTH",
+"164 913 OFFCURVE",
+"153 916 OFFCURVE",
+"144 916 CURVE SMOOTH",
+"138 916 OFFCURVE",
+"133 915 OFFCURVE",
+"133 910 CURVE SMOOTH",
+"133 859 OFFCURVE",
+"127 799 OFFCURVE",
+"120 747 CURVE SMOOTH",
+"119 739 OFFCURVE",
+"122 732 OFFCURVE",
+"129 727 CURVE SMOOTH",
+"133 723 OFFCURVE",
+"140 723 OFFCURVE",
+"143 727 CURVE"
+);
+}
+);
+width = 176;
+}
+);
+unicode = 02BA;
+},
+{
+glyphname = primemod;
+lastChange = "2022-02-08 10:30:40 +0000";
 layers = (
 {
-anchors = (
-{
-name = _top;
-position = "{0, 300}";
-}
-);
-background = {
-anchors = (
-{
-name = _top;
-position = "{0, 255}";
-}
-);
-components = (
-{
-name = brevecomb;
-},
-{
-alignment = -1;
-name = tildecomb;
-transform = "{1, 0, 0, 1, 20, 120}";
-}
-);
-};
-components = (
-{
-name = brevecomb;
-},
-{
-alignment = -1;
-name = tildecomb;
-transform = "{1, 0, 0, 1, 20, 110}";
-}
-);
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
+paths = (
+{
+closed = 1;
+nodes = (
+"29 731 OFFCURVE",
+"32 742 OFFCURVE",
+"38 765 CURVE SMOOTH",
+"49 805 OFFCURVE",
+"56 844 OFFCURVE",
+"56 889 CURVE SMOOTH",
+"56 895 OFFCURVE",
+"56 904 OFFCURVE",
+"49 909 CURVE SMOOTH",
+"44 913 OFFCURVE",
+"33 916 OFFCURVE",
+"24 916 CURVE SMOOTH",
+"18 916 OFFCURVE",
+"13 915 OFFCURVE",
+"13 910 CURVE SMOOTH",
+"13 859 OFFCURVE",
+"7 799 OFFCURVE",
+"0 747 CURVE SMOOTH",
+"-1 739 OFFCURVE",
+"2 732 OFFCURVE",
+"9 727 CURVE SMOOTH",
+"13 723 OFFCURVE",
+"20 723 OFFCURVE",
+"23 727 CURVE"
+);
 }
 );
-},
-{
-color = 1;
-glyphname = circumflexcomb_acutecomb;
-lastChange = "2022-02-17 10:26:18 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 300}";
+width = 56;
 }
 );
-background = {
-anchors = (
-{
-name = _top;
-position = "{0, 255}";
-}
-);
-components = (
-{
-name = circumflexcomb;
-},
-{
-alignment = -1;
-name = acutecomb;
-transform = "{1, 0, 0, 1, 90, 90}";
-}
-);
-};
-components = (
-{
-name = circumflexcomb;
-},
-{
-alignment = -1;
-name = acutecomb;
-transform = "{1, 0, 0, 1, 70, 70}";
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
-);
-},
-{
-color = 1;
-glyphname = circumflexcomb_gravecomb;
-lastChange = "2022-02-17 10:26:18 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 300}";
-}
-);
-background = {
-anchors = (
-{
-name = _top;
-position = "{0, 255}";
-}
-);
-components = (
-{
-name = circumflexcomb;
-},
-{
-alignment = -1;
-name = gravecomb;
-transform = "{1, 0, 0, 1, 110, 90}";
-}
-);
-};
-components = (
-{
-name = circumflexcomb;
-},
-{
-alignment = -1;
-name = gravecomb;
-transform = "{1, 0, 0, 1, 90, 70}";
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
-);
-},
-{
-color = 1;
-glyphname = circumflexcomb_hookabovecomb;
-lastChange = "2022-02-17 10:26:18 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 300}";
-}
-);
-background = {
-anchors = (
-{
-name = _top;
-position = "{0, 255}";
-}
-);
-components = (
-{
-name = circumflexcomb;
-},
-{
-alignment = -1;
-name = hookabovecomb;
-transform = "{1, 0, 0, 1, 90, 80}";
-}
-);
-};
-components = (
-{
-name = circumflexcomb;
-},
-{
-alignment = -1;
-name = hookabovecomb;
-transform = "{1, 0, 0, 1, 64, 80}";
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
-);
-},
-{
-color = 1;
-glyphname = circumflexcomb_tildecomb;
-lastChange = "2022-02-17 10:26:18 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 300}";
-}
-);
-background = {
-anchors = (
-{
-name = _top;
-position = "{0, 255}";
-}
-);
-components = (
-{
-name = circumflexcomb;
-},
-{
-alignment = -1;
-name = tildecomb;
-transform = "{1, 0, 0, 1, 20, 120}";
-}
-);
-};
-components = (
-{
-name = circumflexcomb;
-},
-{
-alignment = -1;
-name = tildecomb;
-transform = "{1, 0, 0, 1, 12, 110}";
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
-);
+unicode = 02B9;
 },
 {
 color = 2;
@@ -39778,6 +39966,227 @@ width = 0;
 unicode = 0335;
 },
 {
+color = 1;
+glyphname = dieresis;
+lastChange = "2022-02-28 15:22:05 +0000";
+layers = (
+{
+components = (
+{
+name = dieresiscomb;
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
+unicode = 00A8;
+},
+{
+color = 1;
+glyphname = dotaccent;
+lastChange = "2022-02-28 15:22:05 +0000";
+layers = (
+{
+components = (
+{
+name = dotaccentcomb;
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
+unicode = 02D9;
+},
+{
+color = 1;
+glyphname = grave;
+lastChange = "2022-02-28 15:22:05 +0000";
+layers = (
+{
+components = (
+{
+name = gravecomb;
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
+unicode = 0060;
+},
+{
+color = 1;
+glyphname = acute;
+lastChange = "2022-02-28 15:22:05 +0000";
+layers = (
+{
+components = (
+{
+name = acutecomb;
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
+unicode = 00B4;
+},
+{
+color = 1;
+glyphname = hungarumlaut;
+lastChange = "2022-02-28 15:22:05 +0000";
+layers = (
+{
+components = (
+{
+name = hungarumlautcomb;
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
+unicode = 02DD;
+},
+{
+color = 1;
+glyphname = circumflex;
+lastChange = "2022-02-28 15:22:05 +0000";
+layers = (
+{
+components = (
+{
+name = circumflexcomb;
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
+unicode = 02C6;
+},
+{
+color = 1;
+glyphname = caron;
+lastChange = "2022-02-28 15:22:05 +0000";
+layers = (
+{
+components = (
+{
+name = caroncomb;
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
+unicode = 02C7;
+},
+{
+color = 1;
+glyphname = breve;
+lastChange = "2022-02-28 15:22:05 +0000";
+layers = (
+{
+components = (
+{
+name = brevecomb;
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
+unicode = 02D8;
+},
+{
+color = 1;
+glyphname = ring;
+lastChange = "2022-02-28 15:22:05 +0000";
+layers = (
+{
+components = (
+{
+name = ringcomb;
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
+unicode = 02DA;
+},
+{
+color = 1;
+glyphname = tilde;
+lastChange = "2022-02-28 15:22:05 +0000";
+layers = (
+{
+components = (
+{
+name = tildecomb;
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
+unicode = 02DC;
+},
+{
+color = 1;
+glyphname = macron;
+lastChange = "2022-02-28 15:22:05 +0000";
+layers = (
+{
+components = (
+{
+name = macroncomb;
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
+unicode = 00AF;
+},
+{
+color = 1;
+glyphname = cedilla;
+lastChange = "2022-02-28 15:22:05 +0000";
+layers = (
+{
+components = (
+{
+name = cedillacomb;
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
+unicode = 00B8;
+},
+{
+color = 1;
+glyphname = ogonek;
+lastChange = "2022-02-28 15:22:05 +0000";
+layers = (
+{
+components = (
+{
+name = ogonekcomb;
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
+unicode = 02DB;
+},
+{
 color = 3;
 glyphname = dieresiscomb.case;
 lastChange = "2022-02-17 10:36:59 +0000";
@@ -40122,126 +40531,18 @@ width = 0;
 },
 {
 color = 3;
-glyphname = circumflexcomb_gravecomb.case;
-lastChange = "2022-02-17 10:36:56 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 300}";
-}
-);
-components = (
-{
-name = circumflexcomb.case;
-},
-{
-alignment = -1;
-name = gravecomb.case;
-transform = "{1, 0, 0, 1, 110, 90}";
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
-);
-},
-{
-color = 3;
-glyphname = circumflexcomb_acutecomb.case;
-lastChange = "2022-02-17 10:36:56 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 300}";
-}
-);
-components = (
-{
-name = circumflexcomb.case;
-},
-{
-alignment = -1;
-name = acutecomb.case;
-transform = "{1, 0, 0, 1, 90, 90}";
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
-);
-},
-{
-color = 3;
-glyphname = circumflexcomb_tildecomb.case;
-lastChange = "2022-02-17 10:36:56 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 300}";
-}
-);
-components = (
-{
-name = circumflexcomb.case;
-},
-{
-alignment = -1;
-name = tildecomb.case;
-transform = "{1, 0, 0, 1, 20, 120}";
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
-);
-},
-{
-color = 3;
-glyphname = circumflexcomb_hookabovecomb.case;
-lastChange = "2022-02-17 10:36:56 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 300}";
-}
-);
-components = (
-{
-name = circumflexcomb.case;
-},
-{
-alignment = -1;
-name = hookabovecomb.case;
-transform = "{1, 0, 0, 1, 90, 80}";
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
-);
-},
-{
-color = 3;
 glyphname = caroncomb.case;
-lastChange = "2022-02-17 10:36:59 +0000";
+lastChange = "2022-02-28 13:18:25 +0000";
 layers = (
 {
 anchors = (
 {
 name = _top;
-position = "{0, 255}";
+position = "{0, 300}";
 },
 {
 name = top;
-position = "{0, 375}";
+position = "{0, 420}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
@@ -40334,111 +40635,6 @@ nodes = (
 );
 }
 );
-width = 0;
-}
-);
-},
-{
-color = 3;
-glyphname = brevecomb_gravecomb.case;
-lastChange = "2022-02-17 10:36:59 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 300}";
-}
-);
-components = (
-{
-name = brevecomb.case;
-},
-{
-name = gravecomb.case;
-transform = "{1, 0, 0, 1, 0, 120}";
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
-);
-},
-{
-color = 3;
-glyphname = brevecomb_acutecomb.case;
-lastChange = "2022-02-17 10:36:59 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 300}";
-}
-);
-components = (
-{
-name = brevecomb.case;
-},
-{
-name = acutecomb.case;
-transform = "{1, 0, 0, 1, 0, 120}";
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
-);
-},
-{
-color = 3;
-glyphname = brevecomb_tildecomb.case;
-lastChange = "2022-02-17 10:36:56 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 300}";
-}
-);
-components = (
-{
-name = brevecomb.case;
-},
-{
-alignment = -1;
-name = tildecomb.case;
-transform = "{1, 0, 0, 1, 20, 131}";
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
-);
-},
-{
-color = 3;
-glyphname = brevecomb_hookabovecomb.case;
-lastChange = "2022-02-17 10:36:59 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 300}";
-}
-);
-components = (
-{
-name = brevecomb.case;
-},
-{
-name = hookabovecomb.case;
-transform = "{1, 0, 0, 1, 0, 120}";
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
 width = 0;
 }
 );
@@ -41293,386 +41489,574 @@ width = 0;
 );
 },
 {
-color = 3;
-glyphname = dieresis;
-lastChange = "2022-02-10 16:56:36 +0000";
+color = 1;
+glyphname = brevecomb_acutecomb;
+lastChange = "2022-02-17 10:26:18 +0000";
 layers = (
 {
-components = (
+anchors = (
 {
-name = dieresiscomb;
+name = _top;
+position = "{0, 300}";
 }
 );
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
+background = {
+anchors = (
+{
+name = _top;
+position = "{0, 255}";
 }
 );
-unicode = 00A8;
-},
-{
-color = 3;
-glyphname = dotaccent;
-lastChange = "2022-02-10 16:56:36 +0000";
-layers = (
-{
-components = (
-{
-name = dotaccentcomb;
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
-);
-unicode = 02D9;
-},
-{
-color = 3;
-glyphname = grave;
-lastChange = "2022-02-10 16:56:36 +0000";
-layers = (
-{
-components = (
-{
-name = gravecomb;
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
-);
-unicode = 0060;
-},
-{
-color = 3;
-glyphname = acute;
-lastChange = "2022-02-10 16:56:36 +0000";
-layers = (
-{
-components = (
-{
-name = acutecomb;
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
-);
-unicode = 00B4;
-},
-{
-color = 3;
-glyphname = hungarumlaut;
-lastChange = "2022-02-10 16:56:36 +0000";
-layers = (
-{
-components = (
-{
-name = hungarumlautcomb;
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
-);
-unicode = 02DD;
-},
-{
-color = 3;
-glyphname = circumflex;
-lastChange = "2022-02-10 16:56:36 +0000";
-layers = (
-{
-components = (
-{
-name = circumflexcomb;
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
-);
-unicode = 02C6;
-},
-{
-color = 3;
-glyphname = caron;
-lastChange = "2022-02-10 16:56:36 +0000";
-layers = (
-{
-components = (
-{
-name = caroncomb;
-}
-);
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-width = 0;
-}
-);
-unicode = 02C7;
-},
-{
-color = 3;
-glyphname = breve;
-lastChange = "2022-02-10 16:56:36 +0000";
-layers = (
-{
 components = (
 {
 name = brevecomb;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 0, 120}";
+}
+);
+};
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, 10, 90}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
 width = 0;
 }
 );
-unicode = 02D8;
 },
 {
-color = 3;
-glyphname = ring;
-lastChange = "2022-02-10 16:56:36 +0000";
+color = 1;
+glyphname = brevecomb_gravecomb;
+lastChange = "2022-02-17 10:26:18 +0000";
 layers = (
 {
+anchors = (
+{
+name = _top;
+position = "{0, 300}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{0, 255}";
+}
+);
 components = (
 {
-name = ringcomb;
+name = brevecomb;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 0, 120}";
+}
+);
+};
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = gravecomb;
+transform = "{1, 0, 0, 1, 10, 90}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
 width = 0;
 }
 );
-unicode = 02DA;
 },
 {
-color = 3;
-glyphname = tilde;
-lastChange = "2022-02-10 16:56:36 +0000";
+color = 1;
+glyphname = brevecomb_hookabovecomb;
+lastChange = "2022-02-17 10:26:18 +0000";
 layers = (
 {
+anchors = (
+{
+name = _top;
+position = "{0, 300}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{0, 255}";
+}
+);
 components = (
 {
+name = brevecomb;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 0, 120}";
+}
+);
+};
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 10, 80}";
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
+},
+{
+color = 1;
+glyphname = brevecomb_tildecomb;
+lastChange = "2022-02-17 10:26:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{0, 300}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{0, 255}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
 name = tildecomb;
+transform = "{1, 0, 0, 1, 20, 120}";
+}
+);
+};
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = tildecomb;
+transform = "{1, 0, 0, 1, 20, 110}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
 width = 0;
 }
 );
-unicode = 02DC;
+},
+{
+color = 1;
+glyphname = circumflexcomb_acutecomb;
+lastChange = "2022-02-17 10:26:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{0, 300}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{0, 255}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, 90, 90}";
+}
+);
+};
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, 70, 70}";
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
+},
+{
+color = 1;
+glyphname = circumflexcomb_gravecomb;
+lastChange = "2022-02-17 10:26:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{0, 300}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{0, 255}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = gravecomb;
+transform = "{1, 0, 0, 1, 110, 90}";
+}
+);
+};
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = gravecomb;
+transform = "{1, 0, 0, 1, 90, 70}";
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
+},
+{
+color = 1;
+glyphname = circumflexcomb_hookabovecomb;
+lastChange = "2022-02-17 10:26:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{0, 300}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{0, 255}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 90, 80}";
+}
+);
+};
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 64, 80}";
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
+},
+{
+color = 1;
+glyphname = circumflexcomb_tildecomb;
+lastChange = "2022-02-17 10:26:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{0, 300}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{0, 255}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = tildecomb;
+transform = "{1, 0, 0, 1, 20, 120}";
+}
+);
+};
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = tildecomb;
+transform = "{1, 0, 0, 1, 12, 110}";
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
 },
 {
 color = 3;
-glyphname = macron;
-lastChange = "2022-02-10 16:56:36 +0000";
+glyphname = brevecomb_acutecomb.case;
+lastChange = "2022-02-17 10:36:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = _top;
+position = "{0, 300}";
+}
+);
 components = (
 {
-name = macroncomb;
+name = brevecomb.case;
+},
+{
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 0, 120}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
 width = 0;
 }
 );
-unicode = 00AF;
 },
 {
 color = 3;
-glyphname = cedilla;
-lastChange = "2022-02-10 16:56:36 +0000";
+glyphname = brevecomb_gravecomb.case;
+lastChange = "2022-02-17 10:36:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = _top;
+position = "{0, 300}";
+}
+);
 components = (
 {
-name = cedillacomb;
+name = brevecomb.case;
+},
+{
+name = gravecomb.case;
+transform = "{1, 0, 0, 1, 0, 120}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
 width = 0;
 }
 );
-unicode = 00B8;
 },
 {
 color = 3;
-glyphname = ogonek;
-lastChange = "2022-02-10 16:56:36 +0000";
+glyphname = brevecomb_hookabovecomb.case;
+lastChange = "2022-02-17 10:36:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = _top;
+position = "{0, 300}";
+}
+);
 components = (
 {
-name = ogonekcomb;
+name = brevecomb.case;
+},
+{
+name = hookabovecomb.case;
+transform = "{1, 0, 0, 1, 0, 120}";
 }
 );
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
 width = 0;
 }
 );
-unicode = 02DB;
 },
 {
-glyphname = apostrophemod;
-lastChange = "2022-02-08 10:30:40 +0000";
+color = 3;
+glyphname = brevecomb_tildecomb.case;
+lastChange = "2022-02-17 10:36:56 +0000";
 layers = (
 {
+anchors = (
+{
+name = _top;
+position = "{0, 300}";
+}
+);
+components = (
+{
+name = brevecomb.case;
+},
+{
+alignment = -1;
+name = tildecomb.case;
+transform = "{1, 0, 0, 1, 20, 131}";
+}
+);
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"0 920 OFFCURVE"
+width = 0;
+}
 );
 },
 {
-closed = 1;
-nodes = (
-"29 711 OFFCURVE",
-"32 722 OFFCURVE",
-"38 745 CURVE SMOOTH",
-"49 785 OFFCURVE",
-"56 844 OFFCURVE",
-"56 889 CURVE SMOOTH",
-"56 895 OFFCURVE",
-"56 904 OFFCURVE",
-"49 909 CURVE SMOOTH",
-"44 913 OFFCURVE",
-"33 916 OFFCURVE",
-"24 916 CURVE SMOOTH",
-"18 916 OFFCURVE",
-"13 915 OFFCURVE",
-"13 910 CURVE SMOOTH",
-"13 859 OFFCURVE",
-"7 779 OFFCURVE",
-"0 727 CURVE SMOOTH",
-"-1 719 OFFCURVE",
-"2 712 OFFCURVE",
-"9 707 CURVE SMOOTH",
-"13 703 OFFCURVE",
-"20 703 OFFCURVE",
-"23 707 CURVE"
-);
-}
-);
-width = 56;
-}
-);
-unicode = 02BC;
-},
-{
-glyphname = doubleprimemod;
-lastChange = "2022-02-08 10:30:40 +0000";
+color = 3;
+glyphname = circumflexcomb_acutecomb.case;
+lastChange = "2022-02-17 10:36:56 +0000";
 layers = (
 {
+anchors = (
+{
+name = _top;
+position = "{0, 300}";
+}
+);
+components = (
+{
+name = circumflexcomb.case;
+},
+{
+alignment = -1;
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 90, 90}";
+}
+);
 layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
-{
-closed = 1;
-nodes = (
-"29 731 OFFCURVE",
-"32 742 OFFCURVE",
-"38 765 CURVE SMOOTH",
-"49 805 OFFCURVE",
-"56 844 OFFCURVE",
-"56 889 CURVE SMOOTH",
-"56 895 OFFCURVE",
-"56 904 OFFCURVE",
-"49 909 CURVE SMOOTH",
-"44 913 OFFCURVE",
-"33 916 OFFCURVE",
-"24 916 CURVE SMOOTH",
-"18 916 OFFCURVE",
-"13 915 OFFCURVE",
-"13 910 CURVE SMOOTH",
-"13 859 OFFCURVE",
-"7 799 OFFCURVE",
-"0 747 CURVE SMOOTH",
-"-1 739 OFFCURVE",
-"2 732 OFFCURVE",
-"9 727 CURVE SMOOTH",
-"13 723 OFFCURVE",
-"20 723 OFFCURVE",
-"23 727 CURVE"
+width = 0;
+}
 );
 },
 {
-closed = 1;
-nodes = (
-"149 731 OFFCURVE",
-"152 742 OFFCURVE",
-"158 765 CURVE SMOOTH",
-"169 805 OFFCURVE",
-"176 844 OFFCURVE",
-"176 889 CURVE SMOOTH",
-"176 895 OFFCURVE",
-"176 904 OFFCURVE",
-"169 909 CURVE SMOOTH",
-"164 913 OFFCURVE",
-"153 916 OFFCURVE",
-"144 916 CURVE SMOOTH",
-"138 916 OFFCURVE",
-"133 915 OFFCURVE",
-"133 910 CURVE SMOOTH",
-"133 859 OFFCURVE",
-"127 799 OFFCURVE",
-"120 747 CURVE SMOOTH",
-"119 739 OFFCURVE",
-"122 732 OFFCURVE",
-"129 727 CURVE SMOOTH",
-"133 723 OFFCURVE",
-"140 723 OFFCURVE",
-"143 727 CURVE"
-);
-}
-);
-width = 176;
-}
-);
-unicode = 02BA;
-},
-{
-glyphname = primemod;
-lastChange = "2022-02-08 10:30:40 +0000";
+color = 3;
+glyphname = circumflexcomb_gravecomb.case;
+lastChange = "2022-02-17 10:36:56 +0000";
 layers = (
 {
-layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
-paths = (
+anchors = (
 {
-closed = 1;
-nodes = (
-"29 731 OFFCURVE",
-"32 742 OFFCURVE",
-"38 765 CURVE SMOOTH",
-"49 805 OFFCURVE",
-"56 844 OFFCURVE",
-"56 889 CURVE SMOOTH",
-"56 895 OFFCURVE",
-"56 904 OFFCURVE",
-"49 909 CURVE SMOOTH",
-"44 913 OFFCURVE",
-"33 916 OFFCURVE",
-"24 916 CURVE SMOOTH",
-"18 916 OFFCURVE",
-"13 915 OFFCURVE",
-"13 910 CURVE SMOOTH",
-"13 859 OFFCURVE",
-"7 799 OFFCURVE",
-"0 747 CURVE SMOOTH",
-"-1 739 OFFCURVE",
-"2 732 OFFCURVE",
-"9 727 CURVE SMOOTH",
-"13 723 OFFCURVE",
-"20 723 OFFCURVE",
-"23 727 CURVE"
-);
+name = _top;
+position = "{0, 300}";
 }
 );
-width = 56;
+components = (
+{
+name = circumflexcomb.case;
+},
+{
+alignment = -1;
+name = gravecomb.case;
+transform = "{1, 0, 0, 1, 110, 90}";
 }
 );
-unicode = 02B9;
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
+},
+{
+color = 3;
+glyphname = circumflexcomb_hookabovecomb.case;
+lastChange = "2022-02-17 10:36:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{0, 300}";
+}
+);
+components = (
+{
+name = circumflexcomb.case;
+},
+{
+alignment = -1;
+name = hookabovecomb.case;
+transform = "{1, 0, 0, 1, 90, 80}";
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
+},
+{
+color = 3;
+glyphname = circumflexcomb_tildecomb.case;
+lastChange = "2022-02-17 10:36:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{0, 300}";
+}
+);
+components = (
+{
+name = circumflexcomb.case;
+},
+{
+alignment = -1;
+name = tildecomb.case;
+transform = "{1, 0, 0, 1, 20, 120}";
+}
+);
+layerId = "5ED96FCC-ACEE-47D8-A1F6-56FBB5DDEA2A";
+width = 0;
+}
+);
 },
 {
 glyphname = Robbie;
@@ -44294,6 +44678,9 @@ dong = {
 "@MMK_R_two" = 100;
 "@MMK_R_zero" = 80;
 };
+eogonek = {
+"@MMK_R_p" = 50;
+};
 exclam = {
 "@MMK_R_quotes" = 70;
 };
@@ -44369,8 +44756,44 @@ yen = {
 "@MMK_R_two" = 90;
 "@MMK_R_zero" = 60;
 };
-eogonek = {
-"@MMK_R_p" = 50;
+"@MMK_L_o" = {
+"@MMK_R_t" = 0;
+};
+ohorn = {
+"@MMK_R_t" = 50;
+};
+ohornacute = {
+"@MMK_R_t" = 50;
+};
+ohorndotbelow = {
+"@MMK_R_t" = 50;
+};
+ohorngrave = {
+"@MMK_R_t" = 50;
+};
+ohornhookabove = {
+"@MMK_R_t" = 50;
+};
+ohorntilde = {
+"@MMK_R_t" = 50;
+};
+uhorn = {
+"@MMK_R_t" = 40;
+};
+uhornacute = {
+"@MMK_R_t" = 40;
+};
+uhorndotbelow = {
+"@MMK_R_t" = 40;
+};
+uhorngrave = {
+"@MMK_R_t" = 40;
+};
+uhornhookabove = {
+"@MMK_R_t" = 40;
+};
+uhorntilde = {
+"@MMK_R_t" = 40;
 };
 };
 };


### PR DESCRIPTION
Original diacritics were too large for lowercase. They are now used as .case diacritics. Narrower and lower variants were made for the lowercase.

Anchors were repositioned to have them nearer to the base glyph. Uppercase and lowercase.

t.alt and dcroat.alt were added including substitution rules in calt feature were added to prevent clashes in diacritics.

i.alt with a higher positioned dot was added to prevent clashes in diacritics. Including substitution rules in calt feature.